### PR TITLE
Changes in find_classification_disagreements.R

### DIFF
--- a/Clean workflow
+++ b/Clean workflow
@@ -413,6 +413,12 @@ What each argument in the RScript is (keep in order and separate with a space):
 	otus.custom.blast.table.modified	the modified blast table produced in step 4.
 	98									the pident cutoff used to create this BLAST table
 	plots								the folder your generated plots will be saved in
+	https://cran.mtu.edu				this is an OPTIONAL argument for those who
+										1. don't have the "reshape" R package installed already
+										2. live far away from the midwestern USA
+										It's the web address to the cran mirror you use, choosing
+										one close to you could make it slightly faster but
+										this honestly doesn't matter much.   
 
 What each generated file is:
 	BLAST_hits_line_plot.png

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -192,6 +192,10 @@ uniform.unclass.names.database <- function(TaxonomyDatabase){
                  tax[,-1] == "Unidentified" | tax[,-1] == "UnIdentified" | tax[,-1] == "UNIDENTIFIED")
   tax[,-1][index] <- "unclassified"
   
+  # Also change any empty names to "unclassified" for ex. GG will say c__(100) for an unknown class it sorted into.
+  index2 <- grep(pattern = '.{1}__\\(\\d{0,3}\\)', x = tax[,-1], value = FALSE, invert = FALSE)
+  tax[,-1][index2] <- "unclassified" 
+  
   return(tax)
 }
 

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -174,7 +174,7 @@ uniform.unclass.names <- function(TaxonomyTable){
       odd.entries,
       "\n\nThese names will be renamed as \"unclassified\". If that seems incorrect",
       "then you have to figure out why the parentheses are missing from them.", 
-      "\nHave ALL your names here? Check that in the step 8 mothur command probs=T\n")
+      "\nHave ALL your names here? Check that in the step 8 mothur command probs=T\n\n")
   }
   
   # Change all those names to unclassified (sometimes, for example, they might be "unknown")

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -157,6 +157,7 @@ find.fw.indeces <- function(TaxonomyTable, SeqIDs){
 # makes all the unclassified/unknown/any other word for it names be uniformly called "unclassified"
   # finds them b/c those names do not have bootstrap percents in parentheses, i.e. the (70)
   # also changes k__(100) etc to unclassified
+  # this is used in the function do.bootstrap.cutoff()
 uniform.unclass.names <- function(TaxonomyTable){
   tax <- TaxonomyTable
   
@@ -223,6 +224,9 @@ make.unclassified <- function(text,val){
 do.bootstrap.cutoff <- function(TaxonomyTable, BootstrapCutoff){
   tax <- as.matrix(TaxonomyTable)
   cutoff <- BootstrapCutoff
+  
+  # make all unclassified things uniformly called "unclassified"
+  tax <- uniform.unclass.names(TaxonomyTable = tax)
   
   # create a matrix of bootstrap numbers and then a T/F matrix
   tax.nums <- apply(tax[,2:ncol(tax)],2,pull.out.percent)
@@ -329,8 +333,7 @@ if (final.or.database == "database"){
   gg <- do.bootstrap.cutoff(TaxonomyTable = gg.percents, BootstrapCutoff = taxonomy.bootstrap.cutoff)
   check.files.match(FWtable = fw, GGtable = gg)
   gg <- apply(gg.percents, 2, remove.parentheses)
-  
-  #it's not callin g__() unc;assified! uh oh
+
 }
 
 

--- a/tax-scripts/plot_blast_hit_stats.R
+++ b/tax-scripts/plot_blast_hit_stats.R
@@ -16,19 +16,20 @@
 # Receive arguments from terminal command line
 #####
 
-userprefs <- commandArgs(trailingOnly = TRUE)
-blast.file.path <- userprefs[1]
-pident.cutoff <- as.numeric(userprefs[2])
-plots.folder.path <- userprefs[3]
-if (length(userprefs) > 3){
-  mirror.location <- userprefs[4]
-}else{
-  mirror.location <- "https://cran.mtu.edu"
-}
+# userprefs <- commandArgs(trailingOnly = TRUE)
+# blast.file.path <- userprefs[1]
+# pident.cutoff <- as.numeric(userprefs[2])
+# plots.folder.path <- userprefs[3]
+# if (length(userprefs) > 3){
+#   mirror.location <- userprefs[4]
+# }else{
+#   mirror.location <- "https://cran.mtu.edu"
+# }
 
-# blast.file.path <- "../../take9c/otus.custom.blast.table.modified"
-# pident.cutoff <- 98
-# plots.folder.path <- "../../take9c/plots"
+blast.file.path <- "../../take9c/otus.custom.blast.table.modified"
+pident.cutoff <- 98
+plots.folder.path <- "../../take9c/plots"
+mirror.location <- "https://cran.mtu.edu"
 
 #####
 # Install Necessary Packages
@@ -140,7 +141,7 @@ bar.plot.stacked.blast.results <- function(BlastTable, CutoffVector, OutputFolde
   
   # create a matrix from which to plot a stacked bar chart
   hits.matrix <- matrix(data = 0,nrow = num.hits.reported, ncol = length(cutoffs))
-  colnames(hits.matrix) <- paste("pident", cutoffs, sep="")
+  colnames(hits.matrix) <- paste("", cutoffs, sep="")
   row.names(hits.matrix) <- paste("hit",1:num.hits.reported, sep="")
   
   # get hit stats for each cutoff
@@ -161,10 +162,17 @@ bar.plot.stacked.blast.results <- function(BlastTable, CutoffVector, OutputFolde
   
   png(filename = paste(plot.folder, "/BLAST_hits_used_for_pidents_", min(CutoffVector), "-", max(CutoffVector), ".png", sep = ""), 
       width = 8, height = 5, units = "in", res = 100)
-  barplot(hits.matrix, ylim = c(0,100), col=rainbow(num.hits.reported),
-          main = "Which BLAST hit gave the best \"full length\" pident?\n(remember blast reports hits in order of its \"alignment length\" pident",
-          xlab = "Full length percent identity cutoff applied to blast results", 
-          ylab = "Percent of best pidents resulting from each blast hit number (%)")
+  par(mar = c(8.5,5,4,.4))
+  barplot(hits.matrix, ylim = c(0,100), col=c("grey",rainbow(num.hits.reported-1)),
+          main = "Which BLAST hit gave the best \"full length\" pident?",
+          xlab = "Full length pident cutoff used to filter seqIDs (%)", 
+          ylab = "SeqIDs corresponding to each blast hit number (%)")
+  description <- paste("The grey bar is blast hit #1. These are the percent of seqIDs where both you and blast calculated the same hit to have the best pident.\n",
+                       "The colored bars are blast hits #2 - ", num.hits.reported, ". These are the percent of seqIDs where the calculated full length pident was better for a different hit.\n",
+                       "At a more stringent pident filter (x axis), fewer poor matches exist so BLAST reports longer matches leading to fewer discrepancies.\n",
+                       "However, if there is a lot of color in your chosen pident's bar you must adjust the BLAST settings to correct that!\n",
+                       sep = "")
+  mtext(text = description, side = 1, line = 7.5, at = -2, cex = .75, adj = 0)
   dev.off()
   
 #   legend(x = num.hits.reported+1, y = 100, legend = row.names(hits.matrix), 

--- a/tax-scripts/plot_blast_hit_stats.R
+++ b/tax-scripts/plot_blast_hit_stats.R
@@ -16,20 +16,20 @@
 # Receive arguments from terminal command line
 #####
 
-# userprefs <- commandArgs(trailingOnly = TRUE)
-# blast.file.path <- userprefs[1]
-# pident.cutoff <- as.numeric(userprefs[2])
-# plots.folder.path <- userprefs[3]
-# if (length(userprefs) > 3){
-#   mirror.location <- userprefs[4]
-# }else{
-#   mirror.location <- "https://cran.mtu.edu"
-# }
+userprefs <- commandArgs(trailingOnly = TRUE)
+blast.file.path <- userprefs[1]
+pident.cutoff <- as.numeric(userprefs[2])
+plots.folder.path <- userprefs[3]
+if (length(userprefs) > 3){
+  mirror.location <- userprefs[4]
+}else{
+  mirror.location <- "https://cran.mtu.edu"
+}
 
-blast.file.path <- "../../take9c/otus.custom.blast.table.modified"
-pident.cutoff <- 98
-plots.folder.path <- "../../take9c/plots"
-mirror.location <- "https://cran.mtu.edu"
+# blast.file.path <- "../../take9c/otus.custom.blast.table.modified"
+# pident.cutoff <- 98
+# plots.folder.path <- "../../take9c/plots"
+# mirror.location <- "https://cran.mtu.edu"
 
 #####
 # Install Necessary Packages

--- a/tax-scripts/plot_blast_hit_stats.R
+++ b/tax-scripts/plot_blast_hit_stats.R
@@ -20,6 +20,11 @@ userprefs <- commandArgs(trailingOnly = TRUE)
 blast.file.path <- userprefs[1]
 pident.cutoff <- as.numeric(userprefs[2])
 plots.folder.path <- userprefs[3]
+if (length(userprefs) > 3){
+  mirror.location <- userprefs[4]
+}else{
+  mirror.location <- "https://cran.mtu.edu"
+}
 
 # blast.file.path <- "../../take9c/otus.custom.blast.table.modified"
 # pident.cutoff <- 98
@@ -29,14 +34,14 @@ plots.folder.path <- userprefs[3]
 # Install Necessary Packages
 #####
 
-# The package reshape is needed
-#****CAN'T SUPPRESS ALL THESE STUPID WARNING MESSAGES!!!****
+# The package reshape is needed, must specify cran mirror and library path with Rscript
+library.path <- cat(.libPaths()) # this is the default installation path
 get.necessary.packages <- function(){
-  if (library(package = "reshape", logical.return = TRUE) == FALSE){
-    install.packages("reshape")
-    library("reshape")
+  if (library(package = "reshape", logical.return = TRUE, lib.loc = library.path) == FALSE){
+    install.packages("reshape", repos = mirror.location)
+    library("reshape", lib.loc = library.path)
   }else{
-    library("reshape")
+    library("reshape", lib.loc = library.path)
   }
 }
 


### PR DESCRIPTION
I added in a "database" option so that you can also compare the classifications btwn the custom and general databases.  

At the same time, I realized an error- the `uniform.unclass.names()` function was never being called! Also, it was missing the empty entries of form `k__(100)` and only picking up ones without parentheses like `unknown`. I fixed that and added that function back into `do.bootstrap.cutoff()` where it was supposed to be.  Must have accidentally deleted it somehow??? 
