### PR TITLE
Suppress 'null device' message. Fixes #47.

### DIFF
--- a/tax-scripts/plot_blast_hit_stats.R
+++ b/tax-scripts/plot_blast_hit_stats.R
@@ -121,14 +121,14 @@ bar.plot.blast.results <- function(BlastHitsTable, OutputFolder, NumBars, Cutoff
     barplot(height = hits.matrix[,2], names.arg = hits.matrix[,1], ylim = c(0,100),
             main = "Which BLAST hit gave the best \"full length\" pident?\n(no cutoff pident applied)",
             xlab = "Hit Number", ylab = "Percent of Best Hits (%)", col = "lightsalmon")
-    dev.off()
+    garbage <- dev.off()
   }else{
     png(filename = paste(plot.folder, "/BLAST_hits_used_for_pident_", Cutoff, ".png", sep=""), 
         width = 5.5, height = 5, units = "in", res = 100)
     barplot(height = hits.matrix[,2], names.arg = hits.matrix[,1], ylim = c(0,100),
             main = paste("Which BLAST hit gave the best \"full length\" pident?\n(out of seqIDs above cutoff: >=",Cutoff,")",sep=""),
             xlab = "Hit Number", ylab = "Percent of Best Hits (%)", col = "lightsalmon")
-    dev.off()
+    garbage <- dev.off()
   }
 }
 
@@ -173,7 +173,7 @@ bar.plot.stacked.blast.results <- function(BlastTable, CutoffVector, OutputFolde
                        "However, if there is a lot of color in your chosen pident's bar you must adjust the BLAST settings to correct that!\n",
                        sep = "")
   mtext(text = description, side = 1, line = 7.5, at = -2, cex = .75, adj = 0)
-  dev.off()
+  garbage <- dev.off()
   
 #   legend(x = num.hits.reported+1, y = 100, legend = row.names(hits.matrix), 
 #          text.col = rainbow(length(num.hits.reported)))
@@ -200,7 +200,7 @@ line.plot.overlay.blast.results <- function(BlastTable, CutoffVector, OutputFold
   
   # Add a legend:
   legend(x = 4, y = 100, legend = sort(cutoffs, decreasing=T), text.col = rainbow(length(cutoffs))[length(cutoffs):1])
-  dev.off()
+  garbage <- dev.off()
 }
  
 #####

--- a/tax-scripts/plot_classification_disagreements.R
+++ b/tax-scripts/plot_classification_disagreements.R
@@ -271,7 +271,7 @@ plot.num.forced <- function(ConflictSummaryTable, UserArgs, ByReads = FALSE, AsP
     points(x = pidents, y = mismatches[r,], col = color[r], pch = 19, cex =1.3)
   }
   legend("center", legend = row.names(mismatches), text.col = color, cex=1.3)
-  dev.off()
+  garbage <- dev.off()
 }
 
 plot.num.classified.outs <- function(ConflictSummaryTable, UserArgs, ByReads = FALSE, AsPercent = TRUE){
@@ -311,7 +311,7 @@ plot.num.classified.outs <- function(ConflictSummaryTable, UserArgs, ByReads = F
   lines(x = pidents, y = num.fw, col = "lightsalmon", lwd = 1.5)
   points(x = pidents, y = num.fw, col = "lightsalmon", pch = 19, cex = 1.3)
   
-  dev.off()
+  garbage <- dev.off()
 }
   
 plot.bootstrap.percents <- function(FWpValues, GGpValues, UserArgs){
@@ -353,7 +353,7 @@ plot.bootstrap.percents <- function(FWpValues, GGpValues, UserArgs){
   mtext("RDP Classifier Repeatability (that number after your taxonomy name)", side = 2, outer = T, line = 4.9, cex = 1.2)
   
   # finish plotting and create the file
-  dev.off()
+  garbage <- dev.off()
 }
 
 


### PR DESCRIPTION
Suppression of 'null device' message can be achieved via [redirecting the output](http://stackoverflow.com/questions/750703/suppressing-null-device-output-with-r-in-batch-mode).

In step 5, the call to lib.paths() also writes to `stdout`. Because you assign the result of the function call to a variable, I think you'd have to use [sink](https://stat.ethz.ch/R-manual/R-devel/library/base/html/sink.html) to redirect the output, but the path to `NULL` differs on Windows and *nix-based machines.
