### PR TITLE
New step 11 added- database comparison

### DIFF
--- a/Clean workflow
+++ b/Clean workflow
@@ -80,7 +80,7 @@ Summary of Steps and Commands (all commands entered in terminal window):
 16. tidy up (bash)
 	rm custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy otus.general.taxonomy
 	mkdir scripts
-	mv *.py *.R scripts/
+	mv *.py *.R *.sh scripts/
 	mkdir analysis/
 	mv conflicts* plots/ analysis/
 	mkdir data
@@ -902,7 +902,7 @@ mv custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.gene
 Full 2 commands (Type in Terminal):
 
 mkdir scripts
-mv *.py *.R scripts/
+mv *.py *.R *.sh scripts/
 
 Note: I recommend saving all the script versions you used to create your data so you could reproduce it.
 

--- a/Clean workflow
+++ b/Clean workflow
@@ -48,27 +48,36 @@ Summary of Steps and Commands (all commands entered in terminal window):
 9. combine taxonomy files (terminal)
 	cat otus.above.98.custom.wang.taxonomy otus.below.98.general.wang.taxonomy > otus.98.taxonomy
 
-10. assign taxonomy without custom database (mothur, bash)
+10. assign taxonomy with general database only (mothur, bash)
 	mothur "#classify.seqs(fasta=otus.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
 	cat otus.general.wang.taxonomy > otus.general.taxonomy
 
-11. reformat taxonomy files (bash)
+11. assign taxonomy to custom database with general database (mothur, bash)
+	mothur "#classify.seqs(fasta=custom.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
+	mv custom.general.wang.taxonomy custom.general.taxonomy
+
+12. reformat taxonomy files (bash)
 	sed 's/[[:blank:]]/\;/' <otus.98.taxonomy >otus.98.taxonomy.reformatted
 	mv otus.98.taxonomy.reformatted otus.98.taxonomy
 	sed 's/[[:blank:]]/\;/' <otus.general.taxonomy >otus.general.taxonomy.reformatted
 	mv otus.general.taxonomy.reformatted otus.general.taxonomy
+	sed 's/[[:blank:]]/\;/' <custom.general.taxonomy >custom.general.taxonomy.reformatted
+	mv custom.general.taxonomy.reformatted custom.general.taxonomy
+	sed 's/[[:blank:]]/\;/' <custom.taxonomy >custom.custom.taxonomy
 	
-12. compare taxonomy files (R)
+13. compare taxonomy files (R)
 	mkdir conflicts_98
-	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 70 
+	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 70
+	mkdir conflicts_database
+	Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA 70 database 
 
-13. check that pident cutoff is appropriate (R)
-	Rscript plot_classification_disagreements.R otus.abund plots conflicts_94 94 conflicts_96 96 conflicts_98 98
+14. choose appropriate pident cutoff (R)
+	Rscript plot_classification_disagreements.R otus.abund plots conflicts_database conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
 
-14. generate final taxonomy file (R)
+15. generate final taxonomy file (R)
 	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 70 final
 
-15. tidy up (bash)
+16. tidy up (bash)
 	rm custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy otus.general.taxonomy
 	mkdir scripts
 	mv *.py *.R scripts/
@@ -405,7 +414,7 @@ RScript plot_blast_hit_stats.R otus.custom.blast.table.modified 98 plots
 What mkdir command does:
 	mkdir		stands for "make directory", this creates a new folder
 	plots		the name of the new folder you are creating
-				this is where step 5 and step 13 will save plots generated for checking the cutoff
+				this is where step 5 and step 14 will save plots generated for checking the cutoff
 
 What each argument in the RScript is (keep in order and separate with a space):
 	RScript								sources an R script and allows it to accept arguments from the command line
@@ -577,7 +586,7 @@ NOTE: these bootstrap percent confidence values are NOT the confidence that the 
 assignment is *correct*, just that it is *repeatable* in that database.  This is another 
 paremeter that we could explore changing more in the future.  It likely should be different
 in the different databases also because of the different database sizes.  I left cutoff out
-in this command so that you can explore the different results of it later, in steps 12-13.
+in this command so that you can explore the different results of it later, in steps 13-14.
 
 
 __________________________________________________________________________________________
@@ -604,7 +613,7 @@ What the filenames are:
 
 __________________________________________________________________________________________
 
-Steps 10-13 are an optional check.
+Steps 10-14 are an optional check.
 __________________________________________________________________________________________
 
 10. assign taxonomy with general database only (mothur, bash)
@@ -625,19 +634,52 @@ mothur "#classify.seqs(fasta=otus.fasta, template=general.fasta, taxonomy=genera
 cat otus.general.wang.taxonomy > otus.general.taxonomy
 
 What the commands do:
-	See step 8 for a detailed explanation of these four commands and their arguments.
+	See step 8 for a detailed explanation of these two commands and their arguments.
 
 What the filenames are:
-	otus.fasta			the original fasta file of your OTU sequences
-	general.fasta		the fasta file of the large, general database
-	general.taxonomy	the taxonomy file of the large, general database
+	otus.fasta					the original fasta file of your OTU sequences
+	general.fasta				the fasta file of the large, general database
+	general.taxonomy			the taxonomy file of the large, general database
+	otus.general.wang.taxonomy	the taxonomy of your OTUs assigned by the general database
+								this is the default name created by mothur
+	otus.general.taxonomy		the otus.general.wang.taxonomy file renamed
 
 
 __________________________________________________________________________________________
 
-11. reformat taxonomy files (bash)
+11. assign taxonomy to custom database with general database (mothur, bash)
 
-The R script in step 12 requires semicolon delimited taxonomy files.  The mothur output
+This allows you to compare your two databases to get an idea of the baseline level of 
+disagreement you can expect from their taxonomy classifications.  Also, in step 13 you
+will generate a list of these disagreements that you can use to update your custom
+database classifications to better match your general database, if desired.  When you 
+choose an appropriate pident cutoff the goal is to avoid forcing OTUs into the custom
+database, which can be seen when the general database gives a very different 
+classification. Knowing the level of disagreement between the databases themselves can
+give you an idea of how much disagreement is acceptable.
+
+Full Two Commands (Type in Terminal):
+
+mothur "#classify.seqs(fasta=custom.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
+cat custom.general.wang.taxonomy custom.general.taxonomy
+
+
+What the commands do:
+	See step 8 for a detailed explanation of these two commands and their arguments.
+
+What the filenames are:
+	custom.fasta					the fasta file of the small, custom database
+	general.fasta					the fasta file of the large, general database
+	custom.general.wang.taxonomy	the taxonomy of your custom database assigned by the general database
+									this is the default name created by mothur
+	custom.general.taxonomy			the custom.general.wang.taxonomy file renamed
+	
+	
+__________________________________________________________________________________________
+
+12. reformat taxonomy files (bash)
+
+The R script in step 13 requires semicolon delimited taxonomy files.  The mothur output
 .taxonomy files are delimited with both tabs and semicolons.
 
 Reformat both files you will compare:
@@ -647,12 +689,15 @@ Reformat both files you will compare:
 Find: tab
 Replace: semicolon
 
-Full Four Commands (Type in Terminal):
+Full Seven Commands (Type in Terminal):
 
 sed 's/[[:blank:]]/\;/' <otus.98.taxonomy >otus.98.taxonomy.reformatted
 mv otus.98.taxonomy.reformatted otus.98.taxonomy
 sed 's/[[:blank:]]/\;/' <otus.general.taxonomy >otus.general.taxonomy.reformatted
 mv otus.general.taxonomy.reformatted otus.general.taxonomy
+sed 's/[[:blank:]]/\;/' <custom.general.taxonomy >custom.general.taxonomy.reformatted
+mv custom.general.taxonomy.reformatted custom.general.taxonomy
+sed 's/[[:blank:]]/\;/' <custom.taxonomy >custom.custom.taxonomy
 
 Syntax of commands and what each argument does:
 	sed 's/find/replace/ <input >output
@@ -670,13 +715,9 @@ Syntax of commands and what each argument does:
 				simply keeping the edited file the same name  
 		
 
-***I should use mv above when I rename files too, to keep the total # of crap down
-instead of cat that I think leaves the old file there still too...
-
-
 __________________________________________________________________________________________
 
-12. compare taxonomy files (bash, R)
+13. compare taxonomy files (bash, R)
 
 The R script find_classification_disagreements.R  creates a folder containing a file for 
 each upper taxonomic level (kingdom, phylum, class, order, lineage) that lists all of the 
@@ -710,80 +751,104 @@ Full Two Commands (type in terminal):
 
 mkdir conflicts_98
 Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 70
+mkdir conflicts_database
+Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA 70 database 
 
 Note: you must enter all the arguments in this order.
 
-What the arguments are:
-	Rscript									this opens R to accept arguments from the command line
-	find_classification_disagreements.R		this is the R script you're calling
-	fw.plus.gg.tax.file.path				this is the path to your custom taxonomy file
-											i.e. the path to otus.taxonomy created in step 9
-	gg.only.tax.file.path					this is the path to the general-only taxonomy file
-											i.e. the path to otus.general.taxonomy
-	seq.ids.above.cutoff.file.path			this is the path to the file created in step 4 that
+What the arguments are the first time you source the script:
+1.	Rscript									this opens R to accept arguments from the command line
+2.	find_classification_disagreements.R		this is the R script you're sourcing
+3.	otus.98.taxonomy						this is the path to your otu taxonomy file 
+											created using both databases in step 9
+4.	otus.general.taxonomy					this is the path to your otu taxonomy file
+											created using only the general database in step 10
+5.	ids.above.98							this is the path to the file created in step 4 that
 											contains all of the sequence IDs above or equal to 
-											your BLAST cutoff. i.e. the path to ids.above.98
-	results.folder.path						this is the path to the folder you want the R script
-											to save the .csv results files in.
-											NOTE: you must create this folder before running script!
-	blast.pident.cutoff						this is the pident you're using.
-	taxonomy.bootstrap.cutoff				this is the % confidence cutoff you want to use 
-											on the general database assignments
+											your pident cutoff
+6.	conflicts_98							this is the path to the folder you want the R script
+											to save the .csv results files in. You create this
+											folder in this step with the mkdir command.
+7.	98										this is the pident you're using.
+8.	70										this is the p-value cutoff you want to use to decide
+											if a classification is good enough to be named or 
+											should be left as unclassified. 
 	
-											
+What the arguments are the second time you source the script:
+1.	Rscript									this opens R to accept arguments from the command line
+2.	find_classification_disagreements.R		this is the R script you're sourcing
+3.	custom.custom.taxonomy					this is the path to your custom taxonomy database 
+											after re-formatting it in step 12.
+4.	custom.general.taxonomy					this is the path to your custom taxonomy database
+											classified using the general database in step 11.
+5.	NA										NA is typed as a placeholder here
+6.	conflicts_database						this is the path to the folder you want the R script
+											to save the .csv results files in. You create this
+											folder in this step with the mkdir command.
+7.	NA										NA is typed as a placeholder here
+8.	70										this is the p-value cutoff you want to use to decide
+											if a classification is good enough to be named or 
+											should be left as unclassified. 			
 
-What the generated files in your plots folder are:
+What the generated files in your conflicts folders are:
 	kingdom_conflicts.csv
 	phylum_conflicts.csv
 	class_conflicts.csv
 	order_conflicts.csv
 	lineage_conflicts.csv
+	conflicts_summary.csv
 
 
 __________________________________________________________________________________________
 
-13. check that pident cutoff is appropriate (R)
+14. choose appropriate pident cutoff (R)
 
 This step generates some plots that you can use to double check that your chosen cutoff is 
 appropriate.  The plots are saved into the "plots" folder that you created in step 5.  In
-order to examine the cutoff sensitivity, you may want to run steps 4-9 & 11-12 multiple times
+order to examine the cutoff sensitivity, you may want to run steps 4-9 & 12-14 multiple times
 with different pident cutoffs.  Note that the slowest step, classify.seqs() in mothur, will
-be much faster as long as the mothur database files are still saved.
+be much faster because the mothur database files are not re-made.
 
-Rscript plot_classification_disagreements.R otus.abund plots conflicts_94 94 conflicts_96 96 conflicts_98 98
+Rscript plot_classification_disagreements.R otus.abund plots conflicts_database conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
 
 What the arguments are:
-	Rscript									Calls program R in a way that accepts command line arguments
-	plot_classification_disagreements.R		name of the script you are calling
-	otus.abund								OTU relative abundance table
-	plots									path to folder you are saving the plots into.
-											note: this folder must already exist. you made it in step 5.
-	conflicts_94							path to folder containing taxonomy disagreements between
-											the workflow and the general database alone.
-											You made this folder in step 12.
-	94										pident cutoff for the previous folder
-	conflicts_96							folder of taxonomy disagreements
-	96										pident cutoff for previous folder
-	conflicts_98							folder of taxonomy disagreements
-	98										pident cutoff for previous folder
-	...										you can have as many pident cutoffs compared as you
-											want.  List them all as arguments in this form:
-											folder_path pident folder_path pident ...
+1.		Rscript									Calls program R in a way that accepts command line arguments
+2.		plot_classification_disagreements.R		name of the script you are calling
+3.		otus.abund								OTU relative abundance table
+4.		plots									path to folder you are saving the plots into.
+												note: this folder must already exist. you made it in step 5.
+5.		conflicts_database						path to folder containing taxonomy disagreements between
+												the custom and the general database.
+												You made this folder in step 13.
+6.		conflicts_94							path to folder containing taxonomy disagreements between
+												this cutom+general workflow and the general database alone.
+												You made this folder in step 13.
+7.		ids.above.94							path to the file that lists all the seqIDs meeting your
+												pident cutoff that were therefore classified with your
+												custom databse. You made this file in step 4.
+8.		94										pident cutoff used in the previous two arguments
+8.		conflicts_96							folder of taxonomy disagreements
+9.		ids.above.94							file of custom-classified seqIDs	
+10.		96										pident cutoff for previous two arguments
+n.		...										additional arguments
+												you can have as many pident cutoffs compared as you
+												want.  Just keep listing them in this format:
+												folder_path ids.file pident folder_path ids.file pident ...
 
 What the generated plots are:
 	***choose which ones to export***
 
 __________________________________________________________________________________________
 
-14. generate final taxonomy file (R)
+15. generate final taxonomy file (R)
 
-Based on your results from step 13, choose which pident cutoff to use.  Use the same script 
-from step 12, except this time specify "final."  This final taxonomy file is different from 
+Based on your results from step 14, choose which pident cutoff to use.  Use the same script 
+from step 13, except this time specify "final."  This final taxonomy file is different from 
 files created in step 9 because it applies your clustering bootstrap pvalue cutoff, calling
 everything below that cutoff "unclassified."  
 
 Recall that choosing that cutoff was left out of the mothur command to allow flexibility in
-analyzing results.  The "final" argument to this script is left out in step 12 because it takes
+analyzing results.  The "final" argument to this script is left out in step 13 because it takes
 longer when it is included.  This is because in finding the classification disagreements, the
 script only compares classifications assigned by the custom database, which is a small subset 
 of all of the classifications.
@@ -793,7 +858,7 @@ Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxono
 
 __________________________________________________________________________________________
 
-15. tidy up (bash)
+16. tidy up (bash)
 
 This step tidies up your working directory folder by removing intermediate files you don't 
 need anymore and moving remaining files into orgainized folders.
@@ -801,7 +866,7 @@ Note: these bash commands only work if you've been using the same names as the w
 Note: go through these commands in order.
 
 
-15.1 remove intermediate files
+16.1 remove intermediate files
 
 Full Command (Type in Terminal):
 
@@ -822,7 +887,7 @@ otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy otus.general.taxonomy
 				the classifications at different pident cutoffs and from green genes alone
 				note: these files don't have p-value cutoffs applied (i.e. nothing's called unclassified). 
 				If you want to save files like these for additional analysis, 
-					re-run step 14 to get additional "final" versions.
+					re-run step 15 to get additional "final" versions.
 					re-run step 10 with an additional "cutoff=" flag.
 
 Note: if for some reason you want to keep these files, you can either skip this step
@@ -832,7 +897,7 @@ mkdir intermediate
 mv custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta intermediate/
 
 
-15.2 move scripts into scripts folder
+16.2 move scripts into scripts folder
 
 Full 2 commands (Type in Terminal):
 
@@ -842,7 +907,7 @@ mv *.py *.R scripts/
 Note: I recommend saving all the script versions you used to create your data so you could reproduce it.
 
 
-15.3 save files used in analyzing your results in analysis folder
+16.3 save files used in analyzing your results in analysis folder
 
 Full 2 commands (Type in Terminal):
 
@@ -853,7 +918,7 @@ Note: You can delete this instead if you're all done analyzing. Instead of the t
 
 rm -r conflicts* plots/
 
-15.4 save your actual data files in a folder called data
+16.4 save your actual data files in a folder called data
 
 Full Two commands (Type in Terminal):
 
@@ -863,7 +928,7 @@ mv otus* data/
 Note: Yeyy!  This is what you're gonna use to actually do stuff now!!
 
 
-15.5 save the version of the taxonomy databases you used in a databases folder
+16.5 save the version of the taxonomy databases you used in a databases folder
 
 Full Two Commands (type in terminal):
 

--- a/tax-scripts/LazyRun.sh
+++ b/tax-scripts/LazyRun.sh
@@ -32,15 +32,22 @@ mothur "#classify.seqs(fasta=otus.below.${pident[0]}.fasta, template=general.fas
 cat otus.above.${pident[0]}.custom.wang.taxonomy otus.below.${pident[0]}.general.wang.taxonomy > otus.${pident[0]}.taxonomy
 mothur "#classify.seqs(fasta=otus.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
 cat otus.general.wang.taxonomy > otus.general.taxonomy
+mothur "#classify.seqs(fasta=custom.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
+mv custom.general.wang.taxonomy custom.general.taxonomy
 sed 's/[[:blank:]]/\;/' <otus.${pident[0]}.taxonomy >otus.${pident[0]}.taxonomy.reformatted
 mv otus.${pident[0]}.taxonomy.reformatted otus.${pident[0]}.taxonomy
 sed 's/[[:blank:]]/\;/' <otus.general.taxonomy >otus.general.taxonomy.reformatted
 mv otus.general.taxonomy.reformatted otus.general.taxonomy
+sed 's/[[:blank:]]/\;/' <custom.general.taxonomy >custom.general.taxonomy.reformatted
+mv custom.general.taxonomy.reformatted custom.general.taxonomy
+sed 's/[[:blank:]]/\;/' <custom.taxonomy >custom.custom.taxonomy
 mkdir conflicts_${pident[0]}
 Rscript find_classification_disagreements.R otus.${pident[0]}.taxonomy otus.general.taxonomy ids.above.${pident[0]} conflicts_${pident[0]} ${pident[0]} 70
+mkdir conflicts_database
+Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA 70 database 
 
 # Next Run steps 4-9, the first half of 11, and 12 with different pident cutoffs
-# Define a function called pident since you repeat this part many times
+# Define a function called runagain since you repeat this part many times
 
 runagain () {
    Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.above.$1 $1 TRUE 
@@ -76,10 +83,10 @@ wait
 args_string=""
 for p in ${pident[*]}
 do
-   args_string+=" conflicts_$p $p"
+   args_string+=" conflicts_$p ids.above.$p $p"
 done
 
-Rscript plot_classification_disagreements.R otus.abund plots $args_string
+Rscript plot_classification_disagreements.R otus.abund plots conflicts_database $args_string
 
 printf 'Steps 1-13 have finished running.  Now analysze the plots from step 13 to choose your final pident and generate your final taxonomy file in step 14.  Then tidy up your working directory with step 15. \n \a'
 sleep .1; printf '\a'; sleep .1; printf '\a'; sleep .1; printf '\a'; sleep .1; printf '\a'; sleep .1; printf '\a'; 

--- a/tax-scripts/LazyRun.sh
+++ b/tax-scripts/LazyRun.sh
@@ -10,7 +10,7 @@
 
 # Choose pidents to test over.
 
-pident=("100" "98" "96" "94")
+pident=("100" "99" "98" "97" "96" "95" "94")
 
 # First Run steps 1-12 to generate databases and folders exactly following workflow
 # Note: still gotta do the reformatting on your own (step 0)

--- a/tax-scripts/plot_classification_disagreements.R
+++ b/tax-scripts/plot_classification_disagreements.R
@@ -243,7 +243,7 @@ import.bootstrap.pvalues <- function(UserArgs, FW = TRUE){
 # Define functions to plot the data
 #####
 
-plot.num.forced <- function(ConflictSummaryTable, ResultsFolder, DBconflicts = FALSE, ByReads = FALSE, AsPercent = FALSE, y.axis.limit = 0){
+plot.num.forced <- function(ConflictSummaryTable, ResultsFolder, DBconflicts = as.data.frame(FALSE), ByReads = FALSE, AsPercent = FALSE, y.axis.limit = 0){
   sum.table <- ConflictSummaryTable
   results.file.path <- ResultsFolder
   db.conflicts <- DBconflicts
@@ -276,25 +276,34 @@ plot.num.forced <- function(ConflictSummaryTable, ResultsFolder, DBconflicts = F
     yplotlabel <- paste("_y-axis_cutoff_",ymax, sep = "")
   }
   
+  if (db.conflicts[1,1] == FALSE){
+    db.label <- ""
+    db.plot.label <- ""
+  }else{
+    db.label <- "-DBs_included"
+    db.plot.label <- "\nHorizonal lines show the conflicts between the databases"
+  }
+  
   # Save plot as .png file
-  png(filename = paste(results.file.path, "/Classification_Disagreements_of_", plot.of, "_", plot.as, "s", yplotlabel, ".png", sep = ""), 
+  png(filename = paste(results.file.path, "/Classification_Disagreements_of_", plot.of, "_", plot.as, "s", yplotlabel, db.label, ".png", sep = ""), 
       width = 5, height = 5, units = "in", res = 100)
   
   # Set up an empty plot
   plot(x = 0, type = "n", ylim = c(0,ymax), xlim = c(min(pidents),max(pidents)),
-       main = "Disagreements Between Custom and General Taxonomy Classifications\n(Are we forcing OTUs into our favorite groups?)", cex.main = .8,
+       main = paste("Disagreements Between Custom and General Taxonomy Classifications\n(Are we forcing OTUs into our favorite groups?)", db.plot.label, sep = ""),
+       cex.main = .8,
        ylab = paste("Classification Disagreements (", plot.as, " ", plot.of, "s)", sep = ""), cex.lab = .8, 
        xlab = "\"full length\" pident cutoff (similar to ANI of read to custom database)")
   
   # Fill Plot with beautiful data
   color <- rainbow(nrow(mismatches))
   for (r in 1:nrow(mismatches)){
-    lines(x = pidents, y = mismatches[r,], col = color[r], lwd = 4)
+    lines(x = pidents, y = mismatches[r,], col = color[r], lwd = 2)
     points(x = pidents, y = mismatches[r,], col = color[r], pch = 19, cex =1.3)
   }
   
   # Add database conflicts for baseline, if desired:
-  if (db.conflicts != FALSE){
+  if (db.conflicts[1,1] != FALSE){
     for (r in 1:nrow(db.conflicts)){
       abline(h = db.conflicts[r,2], col = color[r])
     }
@@ -403,7 +412,7 @@ plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.fold
 plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, y.axis.limit = 10)
 # plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE)
 # plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE, y.axis.limit = 1)
-plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, DBconflicts = db.summary, y.axis.limit = 20)
+plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, DBconflicts = db.summary, y.axis.limit = max(db.summary[,2]))
 
 # plot.num.classified.outs(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = FALSE)
 plot.num.classified.outs(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE)

--- a/tax-scripts/plot_classification_disagreements.R
+++ b/tax-scripts/plot_classification_disagreements.R
@@ -62,6 +62,14 @@ import.all.conflict.summaries <- function(ConflictFolders, PidentsUsed){
   return(mismatches.matrix)
 }
 
+# import the database conflicts summary file
+import.database.conflicts <- function(DatabaseFolder){
+  db.conflicts.folder.path <- DatabaseFolder
+  db.conflicts <- read.csv(file = paste(db.conflicts.folder.path, "/conflicts_summary.csv", sep =""), stringsAsFactors = F)
+  # the sequences totals are not needed here
+  return(db.conflicts[1:5,])
+}
+
 # import the OTU table and then pull out just the total reads for each seqID
 import.and.reformat.otu.table <- function(OTUtable){
   otu.table.path <- OTUtable
@@ -378,6 +386,8 @@ plot.bootstrap.percents <- function(FWpValues, GGpValues, UserArgs){
 # examine custom taxonomy disagreements and contribution by number OTUs
 
 otu.summaries <- import.all.conflict.summaries(ConflictFolders = pident.folders, PidentsUsed = pident.values)
+
+db.summary <- import.database.conflicts(DatabaseFolder = db.conflicts.folder.path)
 
 plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path)
 plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, y.axis.limit = 10)

--- a/tax-scripts/plot_classification_disagreements.R
+++ b/tax-scripts/plot_classification_disagreements.R
@@ -9,21 +9,21 @@
 # The variable part is that more pidents can be added, as long as they continue the pattern folder number folder number
 
 # Terminal command line syntax:
-# Rscript plot_classification_disagreements.R otus.abund plots conflicts_94 94 conflicts_96 96 conflicts_98 98 ...
+# Rscript plot_classification_disagreements.R otus.abund plots conflicts_database conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98 ...
 
 #####
 # Receive arguments from terminal command line
 #####
 
-# userprefs <- commandArgs(trailingOnly = TRUE)
+userprefs <- commandArgs(trailingOnly = TRUE)
 
-userprefs <- c("../../take9c/otus.abund",
-               "../../take9c/plots",
-               "../../take9c/conflicts_database",
-               "../../take9c/conflicts_94", "../../take9c/ids.above.94", 94,
-               "../../take9c/conflicts_96", "../../take9c/ids.above.96", 96,
-               "../../take9c/conflicts_98", "../../take9c/ids.above.98", 98,
-               "../../take9c/conflicts_100", "../../take9c/ids.above.100", 100)
+# userprefs <- c("../../take9c/otus.abund",
+#                "../../take9c/plots",
+#                "../../take9c/conflicts_database",
+#                "../../take9c/conflicts_94", "../../take9c/ids.above.94", 94,
+#                "../../take9c/conflicts_96", "../../take9c/ids.above.96", 96,
+#                "../../take9c/conflicts_98", "../../take9c/ids.above.98", 98,
+#                "../../take9c/conflicts_100", "../../take9c/ids.above.100", 100)
 
 otu.table.path <- userprefs[1]
 plots.folder.path <- userprefs[2]
@@ -203,11 +203,10 @@ add.totals.to.read.summaries <- function(ReadSummaryTable, AbundanceTable, Piden
 }
 
 # import bootstrap p-values to compare
-import.bootstrap.pvalues <- function(UserArgs, FW = TRUE){
-  userprefs <- UserArgs
-  user.args <- userprefs[-c(1,2)]
-  pident.folders <- user.args[seq(from = 1, to = length(user.args), by = 2)]
-  pident.values <- user.args[seq(from = 1, to = length(user.args), by = 2)+1]
+import.bootstrap.pvalues <- function(ConflictFolders, PidentsUsed, FW = TRUE){
+  pident.folders <- ConflictFolders
+  pident.values <- PidentsUsed
+  
   if (FW == TRUE){
     db <- "fw"
   }else{
@@ -354,10 +353,10 @@ plot.num.classified.outs <- function(ConflictSummaryTable, ResultsFolder, ByRead
   dev.off()
 }
   
-plot.bootstrap.percents <- function(FWpValues, GGpValues, UserArgs){
+plot.bootstrap.percents <- function(FWpValues, GGpValues, ResultsFolder){
   fw.pvalues <- FWpValues
   gg.pvalues <- GGpValues
-  results.file.path <- UserArgs[2]
+  results.file.path <- ResultsFolder
   
   # set up a new file for the plot
   png(filename = paste(results.file.path, "/Taxonomy_Assignment_Confidences.png", sep = ""), 
@@ -444,9 +443,9 @@ plot.num.classified.outs(ConflictSummaryTable = read.summaries, ResultsFolder = 
 
 # examine pident cutoff relationship to bootstrap p-values
 
-fw.pvalues <- import.bootstrap.pvalues(UserArgs = userprefs, FW = TRUE)
-gg.pvalues <- import.bootstrap.pvalues(UserArgs = userprefs, FW = FALSE)
-
-plot.bootstrap.percents(FWpValues = fw.pvalues, GGpValues = gg.pvalues, UserArgs = userprefs)
+# fw.pvalues <- import.bootstrap.pvalues(ConflictFolders = pident.folders, PidentsUsed = pident.values, FW = TRUE)
+# gg.pvalues <- import.bootstrap.pvalues(ConflictFolders = pident.folders, PidentsUsed = pident.values, FW = FALSE)
+# 
+# plot.bootstrap.percents(FWpValues = fw.pvalues, GGpValues = gg.pvalues, ResultsFolder = plots.folder.path)
 
 

--- a/tax-scripts/plot_classification_disagreements.R
+++ b/tax-scripts/plot_classification_disagreements.R
@@ -243,9 +243,10 @@ import.bootstrap.pvalues <- function(UserArgs, FW = TRUE){
 # Define functions to plot the data
 #####
 
-plot.num.forced <- function(ConflictSummaryTable, ResultsFolder, ByReads = FALSE, AsPercent = FALSE, y.axis.limit = 0){
+plot.num.forced <- function(ConflictSummaryTable, ResultsFolder, DBconflicts = FALSE, ByReads = FALSE, AsPercent = FALSE, y.axis.limit = 0){
   sum.table <- ConflictSummaryTable
   results.file.path <- ResultsFolder
+  db.conflicts <- DBconflicts
   
   # remove the last 2 rows of number FW sequences- totals info not needed for this plot.
   mismatches <- sum.table[1:(nrow(sum.table)-2),]
@@ -291,7 +292,16 @@ plot.num.forced <- function(ConflictSummaryTable, ResultsFolder, ByReads = FALSE
     lines(x = pidents, y = mismatches[r,], col = color[r], lwd = 4)
     points(x = pidents, y = mismatches[r,], col = color[r], pch = 19, cex =1.3)
   }
-  legend("center", legend = row.names(mismatches), text.col = color, cex=1.3)
+  
+  # Add database conflicts for baseline, if desired:
+  if (db.conflicts != FALSE){
+    for (r in 1:nrow(db.conflicts)){
+      abline(h = db.conflicts[r,2], col = color[r])
+    }
+  }
+  
+  legend("topright", legend = row.names(mismatches), text.col = color, cex=1)
+  
   dev.off()
 }
 
@@ -393,6 +403,7 @@ plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.fold
 plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, y.axis.limit = 10)
 # plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE)
 # plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE, y.axis.limit = 1)
+plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, DBconflicts = db.summary, y.axis.limit = 20)
 
 # plot.num.classified.outs(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = FALSE)
 plot.num.classified.outs(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE)


### PR DESCRIPTION
 I added a **new step 11** (yes I know this screws up the numbering in our issues, will fix) 
- new **step 11** runs `classify.seqs()` on the custom database and classifies it with the general database. This lets you compare the database classifications to establish a baseline disagreement.
  - Shaomie's plot idea from lab meeting last fall
- new-numbered **step 12** includes reformatting for the new files also
- new-numbered **step 13** includes a second call to the same script to create the database comparison files.
  - this script `find_classification_disagreements.R` was also edited to accept this
- new-numbered **step 14** has had its script modified and it also has its input arguments modified.  This script was also edited a bunch so that it is much clearer now.
  - this is `plot_classification_disagreements.R`
- new-numbered **step 15** is the same with a new number
- new-numbered **step 16** had a minor edit, the `.sh` files are also moved into the `scripts` folder now.
- the **Clean Workflow.txt** file was updated accordingly
- the **LazyRun.sh** file was updated accordingly
