### PR TITLE
New plot added that shows classification improvements achieved using workflow

### DIFF
--- a/Clean workflow
+++ b/Clean workflow
@@ -77,7 +77,10 @@ Summary of Steps and Commands (all commands entered in terminal window):
 15. generate final taxonomy file (R)
 	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 85 70 final
 
-16. tidy up (bash)
+16. plot classification improvements (R)
+	Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.pvalues total.reads.per.seqID plots
+
+17. tidy up (bash)
 	rm custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy *.general.taxonomy
 	mkdir scripts ; mv *.py *.R *.sh scripts
 	mkdir analysis ; mv conflicts* plots analysis
@@ -874,9 +877,41 @@ What the arguments are this (3rd) time you source the script:
 											therefore it applies the bootstrap p-value cutoff to the
 											entire script instead of just the custom-classified seqIDs.
 											That's why it will take longer this time you run the script.
+
+
 __________________________________________________________________________________________
 
-16. tidy up (bash)
+16. plot classification improvement (R)
+
+In this step two plots are generated that show you the benefit of using the custom workflow.
+The plots show the number of known taxonomic assignments by either % of total OTUs or % of 
+total reads.  Basically, the script sums up everything that is not called "unclassified"
+in the final workflow taxonomy file and the general database taxonomy file with the bootstrap
+p-value cutoffs applied.  These files are both generated in step 15.
+
+Full Command (Type into terminal):
+
+Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.pvalues total.reads.per.seqID plots
+
+What the arguments are:
+	final.taxonomy.pvalues			a file of p-values corresponding to the final taxonomy file you
+									generated in step 15.  This file, with this name, was automatically
+									generated in step 15 so it is already in your working directory.
+	final.general.pvalues 			a file of p-values corresponding to the general-classified taxonomy
+									after the classification p-value cutoff has been applied. This file,
+									with this name, was automatically generated in step 15 so it is already
+									in your working directory.
+	total.reads.per.seqID			a file that lists each seqID and the total number of reads for that
+									seqID.  This file, with this name, was automatically generated in
+									step 14, using your otus.abund table, so it is already in your 
+									working directory.
+	plots							the name of the folder that plots are saved into.  you created this
+									folder in step 5.
+									
+									
+__________________________________________________________________________________________
+
+17. tidy up (bash)
 
 This step tidies up your working directory folder by removing intermediate files you don't 
 need anymore and moving remaining files into orgainized folders.
@@ -884,7 +919,7 @@ Note: these bash commands only work if you've been using the same names as the w
 Note: go through these commands in order.
 
 
-16.1 remove intermediate files
+17.1 remove intermediate files
 
 Full Command (Type in Terminal):
 
@@ -915,7 +950,7 @@ mkdir intermediate
 mv custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy *.general.taxonomy intermediate/
 
 
-16.2 move scripts into scripts folder
+17.2 move scripts into scripts folder
 
 Full 2 commands (Type in Terminal):
 
@@ -925,7 +960,7 @@ mv *.py *.R *.sh scripts/
 Note: I recommend saving all the script versions you used to create your data so you could reproduce it.
 
 
-16.3 save files used in analyzing your results in analysis folder
+17.3 save files used in analyzing your results in analysis folder
 
 Full 2 commands (Type in Terminal):
 
@@ -936,7 +971,7 @@ Note: You can delete this instead if you're all done analyzing. Instead of the t
 
 rm -r conflicts* plots/
 
-16.4 save your actual data files in a folder called data
+17.4 save your actual data files in a folder called data
 
 Full Two commands (Type in Terminal):
 
@@ -946,7 +981,7 @@ mv otus* data/
 Note: Yeyy!  This is what you're gonna use to actually do stuff now!!
 
 
-16.5 save the version of the taxonomy databases you used in a databases folder
+17.5 save the version of the taxonomy databases you used in a databases folder
 
 Full Two Commands (type in terminal):
 

--- a/Clean workflow
+++ b/Clean workflow
@@ -75,7 +75,7 @@ Summary of Steps and Commands (all commands entered in terminal window):
 	Rscript plot_classification_disagreements.R otus.abund plots conflicts_database conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
 
 15. generate final taxonomy file (R)
-	Rscript find_classification_disagreements.R otus.98.taxonomy NA ids.above.98 conflicts_98 98 85 70 final
+	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 85 70 final
 
 16. tidy up (bash)
 	rm custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy *.general.taxonomy
@@ -848,9 +848,32 @@ longer when it is included.  This is because in finding the classification disag
 script only compares classifications assigned by the custom database, which is a small subset 
 of all of the classifications.
 
-Rscript find_classification_disagreements.R otus.98.taxonomy NA ids.above.98 conflicts_98 98 85 70 final
+Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 85 70 final
 
-
+What the arguments are this (3rd) time you source the script:
+1.	Rscript									this opens R to accept arguments from the command line
+2.	find_classification_disagreements.R		this is the R script you're sourcing
+3.	otus.98.taxonomy						this is the path to your otu taxonomy file 
+											created using both databases in step 9
+4.	otus.general.taxonomy					this is the path to your otu taxonomy file
+											created using only the general database in step 10
+5.	ids.above.98							this is the path to the file created in step 4 that
+											contains all of the sequence IDs above or equal to 
+											your pident cutoff
+6.	conflicts_98							this is the path to the folder you want the R script
+											to save the .csv results files in. You create this
+											folder in this step with the mkdir command.
+7.	98										this is the pident you're using.
+8.	85										this is the p-value cutoff for the custom database
+											assigned sequences. This determines if a classification
+											is good enough to be named or should be "unclassified." 
+9.	70										this is the p-value cutoff for the general database
+											assigned sequences. This determines if a classification
+											is good enough to be named or should be "unclassified." 
+10.	final									this flag lets the script know you want a final file generated.
+											therefore it applies the bootstrap p-value cutoff to the
+											entire script instead of just the custom-classified seqIDs.
+											That's why it will take longer this time you run the script.
 __________________________________________________________________________________________
 
 16. tidy up (bash)

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -360,10 +360,22 @@ if (final.or.database == "final" | final.or.database == "Final" | final.or.datab
               file = paste("otus.", blast.pident.cutoff, ".", taxonomy.pvalue.cutoff.fw, ".", taxonomy.pvalue.cutoff.gg, ".taxonomy", sep = ""), 
               sep = ",", row.names = FALSE, col.names = TRUE, quote = FALSE)
   
-  # this will be used by the plot_classification_improvement.R script
+  # the following will be used by the plot_classification_improvement.R script
+  
   tax.nums <- view.bootstraps(TaxonomyTable = final.taxonomy)
   write.table(x = tax.nums, file = "final.taxonomy.pvalues", sep = ",", 
               row.names = FALSE, col.names = TRUE, quote = FALSE)
+  
+  gg.percents <- import.GG.names()
+  gg.percents <- reformat.gg(GGtable = gg.percents)
+  
+  gg.taxonomy <- do.bootstrap.cutoff(TaxonomyTable = gg.percents, BootstrapCutoff = taxonomy.pvalue.cutoff.gg)
+  colnames(gg.taxonomy) <- c("seqID","kingdom","phylum","class","order","lineage","clade","tribe")
+  
+  gg.nums <- view.bootstraps(TaxonomyTable = gg.taxonomy)
+  write.table(x = gg.nums, file = "final.general.pvalues", sep = ",", 
+              row.names = FALSE, col.names = TRUE, quote = FALSE)
+  
 
 
 #####

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -325,7 +325,8 @@ view.bootstraps <- function(TaxonomyTable){
   index <- which(tax.nums == "unclassified")
   tax.nums[index] <- 0
   tax.nums <- apply(X = tax.nums, MARGIN = 2, FUN = as.numeric)
-  
+  tax.nums <- cbind(tax[,1],tax.nums)
+  colnames(tax.nums)[1] <- colnames(tax)[1]
   return(tax.nums)
 }
 
@@ -334,10 +335,10 @@ view.bootstraps <- function(TaxonomyTable){
 # Use Functions
 #####
 
-
+#####
 # Generate a final taxonomy file:
 if (final.or.database == "final" | final.or.database == "Final" | final.or.database == "FINAL"){
-  
+#####  
   print.poem()
   
   fw.percents <- import.FW.names()
@@ -365,9 +366,10 @@ if (final.or.database == "final" | final.or.database == "Final" | final.or.datab
               row.names = FALSE, col.names = TRUE, quote = FALSE)
 
 
+#####
 # Compare databases by looking at how GG classifies the FW representative sequences
 }else if (final.or.database == "database"){
-
+#####
   fw.percents <- import.FW.names()
   gg.percents <- import.GG.names()
   
@@ -395,9 +397,11 @@ if (final.or.database == "final" | final.or.database == "Final" | final.or.datab
   export.summary.stats(SummaryVector = num.mismatches, FW_seqs = fw, ALL_seqs = fw, FolderPath = results.folder.path)
   
 
+  
+##### 
 # Only compare the classifications made by the fw database to the gg classifications, not full tax tables
 }else{
-  
+#####  
   fw.percents <- import.FW.names()
   gg.percents <- import.GG.names()
   
@@ -472,3 +476,4 @@ if (final.or.database == "final" | final.or.database == "Final" | final.or.datab
 # gg.bootstraps <- view.bootstraps(TaxonomyTable = gg.percents.fw.only)
 # write.csv(gg.bootstraps, file = paste(results.folder.path, "/", "gg_classified_bootstraps.csv", sep=""), row.names = FALSE)
 # write.csv(gg.percents.fw.only, file = paste(results.folder.path, "/", "gg_classified_taxonomies.csv", sep=""), row.names = FALSE)
+

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -26,25 +26,17 @@
 # Rscript find_classification_disagreements.R otus.98.taxonomy NA ids.above.98 conflicts_98 98 85 70 final
 # Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA NA 70 database
 
-# userprefs <- commandArgs(trailingOnly = TRUE)
-# fw.plus.gg.tax.file.path <- userprefs[1]
-# gg.only.tax.file.path <- userprefs[2]
-# fw.seq.ids.file.path <- userprefs[3]
-# results.folder.path <- userprefs[4]
-# blast.pident.cutoff <- userprefs[5]
-# taxonomy.pvalue.cutoff.fw <- userprefs[6]
-# taxonomy.pvalue.cutoff.gg <- userprefs[7]
-# final.or.database <- userprefs[8]
-# if (length(userprefs) < 8){final.or.database <- "non-empty string"}
+userprefs <- commandArgs(trailingOnly = TRUE)
 
-userprefs <- c("../../take9c/otus.98.taxonomy",
-               "../../take9c/otus.general.taxonomy",
-               "../../take9c/ids.above.98",
-               "../../take9c/conflicts_98",
-               98, 
-               85, 
-               70,
-               "final")
+# userprefs <- c("../../take9c/otus.98.taxonomy",
+#                "../../take9c/otus.general.taxonomy",
+#                "../../take9c/ids.above.98",
+#                "../../take9c/conflicts_98",
+#                98, 
+#                85, 
+#                70,
+#                "final")
+
 fw.plus.gg.tax.file.path <- userprefs[1]
 gg.only.tax.file.path <- userprefs[2]
 fw.seq.ids.file.path <- userprefs[3]

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -26,25 +26,7 @@
 # Rscript find_classification_disagreements.R otus.98.taxonomy NA ids.above.98 conflicts_98 98 85 70 final
 # Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA NA 70 database
 
-userprefs <- commandArgs(trailingOnly = TRUE)
-fw.plus.gg.tax.file.path <- userprefs[1]
-gg.only.tax.file.path <- userprefs[2]
-fw.seq.ids.file.path <- userprefs[3]
-results.folder.path <- userprefs[4]
-blast.pident.cutoff <- userprefs[5]
-taxonomy.pvalue.cutoff.fw <- userprefs[6]
-taxonomy.pvalue.cutoff.gg <- userprefs[7]
-final.or.database <- userprefs[8]
-if (length(userprefs) < 8){final.or.database <- "non-empty string"}
-
-# userprefs <- c("../../take9b/otus.98.taxonomy",
-#                "../../take9b/otus.general.taxonomy",
-#                "../../take9b/ids.above.98",
-#                "../../take9b/conflicts_98",
-#                98, 
-#                85, 
-#                70,
-#                "final")
+# userprefs <- commandArgs(trailingOnly = TRUE)
 # fw.plus.gg.tax.file.path <- userprefs[1]
 # gg.only.tax.file.path <- userprefs[2]
 # fw.seq.ids.file.path <- userprefs[3]
@@ -54,6 +36,24 @@ if (length(userprefs) < 8){final.or.database <- "non-empty string"}
 # taxonomy.pvalue.cutoff.gg <- userprefs[7]
 # final.or.database <- userprefs[8]
 # if (length(userprefs) < 8){final.or.database <- "non-empty string"}
+
+userprefs <- c("../../take9c/otus.98.taxonomy",
+               "../../take9c/otus.general.taxonomy",
+               "../../take9c/ids.above.98",
+               "../../take9c/conflicts_98",
+               98, 
+               85, 
+               70,
+               "final")
+fw.plus.gg.tax.file.path <- userprefs[1]
+gg.only.tax.file.path <- userprefs[2]
+fw.seq.ids.file.path <- userprefs[3]
+results.folder.path <- userprefs[4]
+blast.pident.cutoff <- userprefs[5]
+taxonomy.pvalue.cutoff.fw <- userprefs[6]
+taxonomy.pvalue.cutoff.gg <- userprefs[7]
+final.or.database <- userprefs[8]
+if (length(userprefs) < 8){final.or.database <- "non-empty string"}
 
 #####
 # Define Functions for Import and Formatting
@@ -357,7 +357,12 @@ if (final.or.database == "final" | final.or.database == "Final" | final.or.datab
   
   write.table(x = final.taxonomy, 
               file = paste("otus.", blast.pident.cutoff, ".", taxonomy.pvalue.cutoff.fw, ".", taxonomy.pvalue.cutoff.gg, ".taxonomy", sep = ""), 
-              sep = ";", row.names = FALSE, col.names = TRUE, quote = FALSE)
+              sep = ",", row.names = FALSE, col.names = TRUE, quote = FALSE)
+  
+  # this will be used by the plot_classification_improvement.R script
+  tax.nums <- view.bootstraps(TaxonomyTable = final.taxonomy)
+  write.table(x = tax.nums, file = "final.taxonomy.pvalues", sep = ",", 
+              row.names = FALSE, col.names = TRUE, quote = FALSE)
 
 
 # Compare databases by looking at how GG classifies the FW representative sequences

--- a/tax-scripts/plot_classification_disagreements.R
+++ b/tax-scripts/plot_classification_disagreements.R
@@ -15,15 +15,15 @@
 # Receive arguments from terminal command line
 #####
 
-userprefs <- commandArgs(trailingOnly = TRUE)
+# userprefs <- commandArgs(trailingOnly = TRUE)
 
-# userprefs <- c("../../take9c/otus.abund",
-#                "../../take9c/plots",
-#                "../../take9c/conflicts_database",
-#                "../../take9c/conflicts_94", "../../take9c/ids.above.94", 94,
-#                "../../take9c/conflicts_96", "../../take9c/ids.above.96", 96,
-#                "../../take9c/conflicts_98", "../../take9c/ids.above.98", 98,
-#                "../../take9c/conflicts_100", "../../take9c/ids.above.100", 100)
+userprefs <- c("../../take9c/otus.abund",
+               "../../take9c/plots",
+               "../../take9c/conflicts_database",
+               "../../take9c/conflicts_94", "../../take9c/ids.above.94", 94,
+               "../../take9c/conflicts_96", "../../take9c/ids.above.96", 96,
+               "../../take9c/conflicts_98", "../../take9c/ids.above.98", 98,
+               "../../take9c/conflicts_100", "../../take9c/ids.above.100", 100)
 
 otu.table.path <- userprefs[1]
 plots.folder.path <- userprefs[2]
@@ -439,6 +439,10 @@ plot.num.forced(ConflictSummaryTable = read.summaries, ResultsFolder = plots.fol
 
 # plot.num.classified.outs(ConflictSummaryTable = read.summaries, ResultsFolder = plots.folder.path, ByReads = TRUE, AsPercent = FALSE)
 plot.num.classified.outs(ConflictSummaryTable = read.summaries, ResultsFolder = plots.folder.path, ByReads = TRUE, AsPercent = TRUE)
+
+# export the reads per seqID for use in the plot_classification_improvement.R script
+write.table(x = seqID.reads, file = "total.reads.per.seqID", sep = ",", row.names = FALSE, col.names = TRUE, quote = FALSE)
+
 
 
 # examine pident cutoff relationship to bootstrap p-values

--- a/tax-scripts/plot_classification_disagreements.R
+++ b/tax-scripts/plot_classification_disagreements.R
@@ -15,15 +15,15 @@
 # Receive arguments from terminal command line
 #####
 
-# userprefs <- commandArgs(trailingOnly = TRUE)
+userprefs <- commandArgs(trailingOnly = TRUE)
 
-userprefs <- c("../../take9c/otus.abund",
-               "../../take9c/plots",
-               "../../take9c/conflicts_database",
-               "../../take9c/conflicts_94", "../../take9c/ids.above.94", 94,
-               "../../take9c/conflicts_96", "../../take9c/ids.above.96", 96,
-               "../../take9c/conflicts_98", "../../take9c/ids.above.98", 98,
-               "../../take9c/conflicts_100", "../../take9c/ids.above.100", 100)
+# userprefs <- c("../../take9c/otus.abund",
+#                "../../take9c/plots",
+#                "../../take9c/conflicts_database",
+#                "../../take9c/conflicts_94", "../../take9c/ids.above.94", 94,
+#                "../../take9c/conflicts_96", "../../take9c/ids.above.96", 96,
+#                "../../take9c/conflicts_98", "../../take9c/ids.above.98", 98,
+#                "../../take9c/conflicts_100", "../../take9c/ids.above.100", 100)
 
 otu.table.path <- userprefs[1]
 plots.folder.path <- userprefs[2]

--- a/tax-scripts/plot_classification_improvement.R
+++ b/tax-scripts/plot_classification_improvement.R
@@ -88,8 +88,10 @@ plot.num.classified <- function(GGTable, FWTable, Reads = TRUE){
   
   if (Reads == TRUE){
     normalizer <- sum(fwpvals[ ,2])
+    title.word <- "Reads"
   }else{
     normalizer <- nrow(ggpvals)
+    title.word <- "OTUs"
   }
   
   gg.classified <- colSums(ggpvals[ ,3:9]) / normalizer * 100
@@ -97,7 +99,10 @@ plot.num.classified <- function(GGTable, FWTable, Reads = TRUE){
   
   class.table <- rbind(gg.classified,fw.classified)
   
-  barplot(class.table, beside = TRUE)
+  
+  barplot(class.table, beside = TRUE, axes = FALSE, col = c("plum4", "orange2"), main = paste("Improvement in", title.word, "Classified"), ylab = paste("Percent total", title.word, "classified"))
+  axis(2, at = seq.int(from = 0, to = 100, by = 20), labels = seq.int(from = 0, to = 100, by = 20), xpd = T)
+  legend(x = "topright", legend = c("General", "Workflow"), fill = c("plum4", "orange2"))
 }
 
 

--- a/tax-scripts/plot_classification_improvement.R
+++ b/tax-scripts/plot_classification_improvement.R
@@ -82,7 +82,17 @@ convert.to.reads.presence.absence <- function(TrueFalseTable){
 # Define functions to plot the data
 #####
 
-plot.num.classified
+plot.num.classified <- function(GGTable, FWTable){
+  ggpvals <- GGTable
+  fwpvals <- FWTable
+  
+  gg.classified <- colSums(ggpvals[ ,3:9])
+  fw.classified <- colSums(fwpvals[ ,3:9])
+  
+  class.table <- rbind(gg.classified,fw.classified)
+  
+  barplot(class.table, beside = TRUE)
+}
 
 
 #####
@@ -103,8 +113,8 @@ otus.named.gg <- convert.to.name.presence.absence(PvaluesTable = gg.pvals)
 reads.named.fw <- convert.to.reads.presence.absence(TrueFalseTable = otus.named.fw)
 reads.named.gg <- convert.to.reads.presence.absence(TrueFalseTable = otus.named.gg)
 
-
-
+plot.num.classified(FWTable = otus.named.gg, GGTable = otus.named.gg)
+plot.num.classified(FWTable = reads.named.fw, GGTable = reads.named.gg)
 
 
 

--- a/tax-scripts/plot_classification_improvement.R
+++ b/tax-scripts/plot_classification_improvement.R
@@ -1,0 +1,112 @@
+# RRR 1/26/16
+
+
+
+taxonomy.pvalues.path <- "../../take9c/final.taxonomy.pvalues"
+reads.table.path <- "../../take9c/total.reads.per.seqID"
+gg.pvalues.path <- "../../take9c/final.general.pvalues"
+
+
+#####
+# Define functions to import data
+#####
+
+import.pvalues <- function(FilePath){
+  taxonomy.pvalues.path <- FilePath
+  pvals <- read.table(file = taxonomy.pvalues.path, header = TRUE, sep = ",", stringsAsFactors = FALSE)
+  pvals[,2:8] <- apply(X = pvals[,2:8], MARGIN = 2, FUN = as.numeric)
+  pvals[,1] <- as.character(pvals[,1])
+  return(pvals)
+}
+
+import.read.counts <- function(FilePath){
+  reads.table.path <- FilePath
+  reads <- read.table(file = reads.table.path, header = TRUE, sep = ",", stringsAsFactors = FALSE)
+  reads[,2] <- as.numeric(reads[,2])
+  reads[,1] <- as.character(reads[,1])
+  return(reads)
+}
+
+
+#####
+# Define functions to manipulate the data
+#####
+
+order.by.seqID.and.combine.tables <- function(ReadsTable, PvaluesTable){
+  reads <- ReadsTable
+  pvals <- PvaluesTable
+  
+  # first check there are no duplicated names- can't have any ties in the order!
+  if (length(pvals$seqID) != length(unique(pvals$seqID)) | length(reads$seqID) != length(unique(reads$seqID)) | length(pvals$seqID) != length(reads$seqID)){
+    cat("uh oh major problem, the number of seqIDs is different in your two tables!")
+  }
+  
+  # this orders numbers as characters, so 1, 10, 100.  oh well, only way to know it will work with character names for seqIDs
+  index.reads <- order(reads[ ,1])
+  index.pvals <- order(pvals[ ,1])
+  reads <- reads[index.reads, ]
+  pvals <- pvals[index.pvals, ]
+  
+  # check that they are in the same order now
+  if (all.equal(reads[,1], pvals[,1])){
+    cat("orders match- good.")
+  }else{
+    cat("crap something's wrong, they didn't end up in the same order.  must fix.")
+  }
+  
+  pvals.with.reads <- cbind(reads, pvals[,2:8])
+  
+  return(pvals.with.reads)
+}
+
+convert.to.name.presence.absence <- function(PvaluesTable){
+  pvals <- PvaluesTable
+  
+  pvals[ ,3:9] <- pvals[ ,3:9] > 0
+  
+  return(pvals)
+}
+
+convert.to.reads.presence.absence <- function(TrueFalseTable){
+  pvals <- TrueFalseTable
+  
+  for (c in 3:9){
+    pvals[ ,c] <- pvals[ ,c] * pvals[ ,2]
+  }
+  
+  return(pvals)
+}
+
+
+#####
+# Define functions to plot the data
+#####
+
+plot.num.classified
+
+
+#####
+# Use functions!
+#####
+
+fw.pvals <- import.pvalues(FilePath = taxonomy.pvalues.path)
+gg.pvals <- import.pvalues(FilePath = gg.pvalues.path)
+
+reads <- import.read.counts(FilePath = reads.table.path)
+
+fw.pvals <- order.by.seqID.and.combine.tables(ReadsTable = reads, PvaluesTable = fw.pvals)
+gg.pvals <- order.by.seqID.and.combine.tables(ReadsTable = reads, PvaluesTable = gg.pvals)
+
+otus.named.fw <- convert.to.name.presence.absence(PvaluesTable = fw.pvals)
+otus.named.gg <- convert.to.name.presence.absence(PvaluesTable = gg.pvals)
+
+reads.named.fw <- convert.to.reads.presence.absence(TrueFalseTable = otus.named.fw)
+reads.named.gg <- convert.to.reads.presence.absence(TrueFalseTable = otus.named.gg)
+
+
+
+
+
+
+
+

--- a/tax-scripts/plot_classification_improvement.R
+++ b/tax-scripts/plot_classification_improvement.R
@@ -1,11 +1,24 @@
 # RRR 1/26/16
 
+# syntax for command line:
 
+# $ Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.pvalues total.reads.per.seqID plots
 
-taxonomy.pvalues.path <- "../../take9c/final.taxonomy.pvalues"
-reads.table.path <- "../../take9c/total.reads.per.seqID"
-gg.pvalues.path <- "../../take9c/final.general.pvalues"
+#####
+# Accept arguments from the command line:
+#####
 
+userprefs <- commandArgs(trailingOnly = TRUE)
+
+taxonomy.pvalues.path <- userprefs[1]
+gg.pvalues.path <- userprefs[2]
+reads.table.path <- userprefs[3]
+path.to.plots.folder <- userprefs[4]
+
+# taxonomy.pvalues.path <- "../../take9c/final.taxonomy.pvalues"
+# gg.pvalues.path <- "../../take9c/final.general.pvalues"
+# reads.table.path <- "../../take9c/total.reads.per.seqID"
+# path.to.plots.folder <- "../../take9c/plots"
 
 #####
 # Define functions to import data
@@ -82,9 +95,10 @@ convert.to.reads.presence.absence <- function(TrueFalseTable){
 # Define functions to plot the data
 #####
 
-plot.num.classified <- function(GGTable, FWTable, Reads = TRUE){
+plot.num.classified <- function(GGTable, FWTable, Reads = TRUE, FolderPath){
   ggpvals <- GGTable
   fwpvals <- FWTable
+  plots.path <- FolderPath
   
   if (Reads == TRUE){
     normalizer <- sum(fwpvals[ ,2])
@@ -99,10 +113,15 @@ plot.num.classified <- function(GGTable, FWTable, Reads = TRUE){
   
   class.table <- rbind(gg.classified,fw.classified)
   
+  # Save plot as .png file
+  png(filename = paste(plots.path, "/Improvement_In_Classification_by_", title.word, ".png", sep = ""), 
+      width = 7, height = 5, units = "in", res = 100)
   
-  barplot(class.table, beside = TRUE, axes = FALSE, col = c("plum4", "orange2"), main = paste("Improvement in", title.word, "Classified"), ylab = paste("Percent total", title.word, "classified"))
+  barplot(class.table, beside = TRUE, axes = FALSE, col = c("plum4", "orange2"), main = paste("Improvement in", title.word, "Classified"), ylab = paste("Percent total", title.word, "classified"), xlab = "Classifications Assigned at Each Taxonomic Level")
   axis(2, at = seq.int(from = 0, to = 100, by = 20), labels = seq.int(from = 0, to = 100, by = 20), xpd = T)
-  legend(x = "topright", legend = c("General", "Workflow"), fill = c("plum4", "orange2"))
+  legend(x = "topright", legend = c("General", "Workflow"), fill = c("plum4", "orange2"), bty = "n")
+  
+  unnecessary.message <- dev.off()
 }
 
 
@@ -124,8 +143,8 @@ otus.named.gg <- convert.to.name.presence.absence(PvaluesTable = gg.pvals)
 reads.named.fw <- convert.to.reads.presence.absence(TrueFalseTable = otus.named.fw)
 reads.named.gg <- convert.to.reads.presence.absence(TrueFalseTable = otus.named.gg)
 
-plot.num.classified(FWTable = otus.named.gg, GGTable = otus.named.gg, Reads = FALSE)
-plot.num.classified(FWTable = reads.named.fw, GGTable = reads.named.gg, Reads = TRUE)
+plot.num.classified(FWTable = otus.named.gg, GGTable = otus.named.gg, Reads = FALSE, FolderPath = path.to.plots.folder)
+plot.num.classified(FWTable = reads.named.fw, GGTable = reads.named.gg, Reads = TRUE, FolderPath = path.to.plots.folder)
 
 
 

--- a/tax-scripts/plot_classification_improvement.R
+++ b/tax-scripts/plot_classification_improvement.R
@@ -82,12 +82,18 @@ convert.to.reads.presence.absence <- function(TrueFalseTable){
 # Define functions to plot the data
 #####
 
-plot.num.classified <- function(GGTable, FWTable){
+plot.num.classified <- function(GGTable, FWTable, Reads = TRUE){
   ggpvals <- GGTable
   fwpvals <- FWTable
   
-  gg.classified <- colSums(ggpvals[ ,3:9])
-  fw.classified <- colSums(fwpvals[ ,3:9])
+  if (Reads == TRUE){
+    normalizer <- sum(fwpvals[ ,2])
+  }else{
+    normalizer <- nrow(ggpvals)
+  }
+  
+  gg.classified <- colSums(ggpvals[ ,3:9]) / normalizer * 100
+  fw.classified <- colSums(fwpvals[ ,3:9]) / normalizer * 100
   
   class.table <- rbind(gg.classified,fw.classified)
   
@@ -113,8 +119,8 @@ otus.named.gg <- convert.to.name.presence.absence(PvaluesTable = gg.pvals)
 reads.named.fw <- convert.to.reads.presence.absence(TrueFalseTable = otus.named.fw)
 reads.named.gg <- convert.to.reads.presence.absence(TrueFalseTable = otus.named.gg)
 
-plot.num.classified(FWTable = otus.named.gg, GGTable = otus.named.gg)
-plot.num.classified(FWTable = reads.named.fw, GGTable = reads.named.gg)
+plot.num.classified(FWTable = otus.named.gg, GGTable = otus.named.gg, Reads = FALSE)
+plot.num.classified(FWTable = reads.named.fw, GGTable = reads.named.gg, Reads = TRUE)
 
 
 


### PR DESCRIPTION
It's a new step 16, and a new r script `plot_classification_improvement.R`

It generates two bar plots, one by %OTUS, one by % reads.

two other scripts were modified to export files this new script needs: 
- `find_classification_disagreements.R` modified to 
  - export the p-values-only table for the final taxonomy
  - also apply bootstrap cutoff to the entire general.taxonomy file and then export it's p-values-only table (this does take a bit of extra time, but it only does this when the "final" flag is used in step 15. 
- `plot_classification_disagreements.R` modified to 
  - export the `seqID.reads` variable it already calculated.  this is a list of each seqID and its corresponding total reads, as calculated from the OTU table.
