### PR TITLE
fixed issue with "unclassified" formatting

### DIFF
--- a/Clean workflow
+++ b/Clean workflow
@@ -907,7 +907,7 @@ p-value cutoffs applied.  These files are both generated in step 15.
 
 Full Command (Type into terminal):
 
-Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.pvalues total.reads.per.seqID plots
+Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.pvalues total.reads.per.seqID.csv plots
 
 What the arguments are:
 	final.taxonomy.pvalues			a file of p-values corresponding to the final taxonomy file you

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -362,7 +362,7 @@ view.bootstraps <- function(TaxonomyTable){
   tax <- TaxonomyTable
   
   # create a matrix of bootstrap numbers, copy from do.bootstrap.cutoff()
-  tax.nums <- apply(tax[,2:ncol(tax)],2,pull.out.percent)
+  tax.nums <- apply(tax[ ,-1], 2, pull.out.percent)
   index <- which(tax.nums == "unclassified")
   tax.nums[index] <- 0
   tax.nums <- apply(X = tax.nums, MARGIN = 2, FUN = as.numeric)

--- a/tax-scripts/find_classification_disagreements.R
+++ b/tax-scripts/find_classification_disagreements.R
@@ -16,9 +16,9 @@
   # the fw.only means that only the seqIDs that the workflow assigned with fw are included in the table
 
 
-#####
+# ####
 # Receive arguments from terminal command line
-#####
+# ####
 
 # Example syntax for pident comparison, final taxonomy generation, and database comparison, respectively:
 
@@ -57,9 +57,9 @@ taxonomy.pvalue.cutoff.gg <- userprefs[7]
 final.or.database <- userprefs[8]
 if (length(userprefs) < 8){final.or.database <- "non-empty string"}
 
-#####
+# ####
 # Define Functions for Import and Formatting
-#####
+# ####
 
 # Entertain user with a poem while they wait:
 print.poem <- function(){
@@ -178,9 +178,9 @@ remove.parentheses <- function(x){
 }
 
 
-#####
+# ####
 # Define Functions for Data Analysis
-#####
+# ####
 
 # Find index of sequences that were classified by the freshwater database. returns a vector of indeces.
 find.fw.indeces <- function(TaxonomyTable, SeqIDs){
@@ -363,14 +363,14 @@ view.bootstraps <- function(TaxonomyTable){
 }
 
 
-#####
+# ####
 # Use Functions
-#####
+# ####
 
-#####
+# ####
 # Generate a final taxonomy file:
 if (final.or.database == "final" | final.or.database == "Final" | final.or.database == "FINAL"){
-#####  
+# ####  
   cat("\n\ngenerating final file- woohoo!\n\n")
   print.poem()
   
@@ -410,10 +410,10 @@ if (final.or.database == "final" | final.or.database == "Final" | final.or.datab
               row.names = FALSE, col.names = TRUE, quote = FALSE)
   
 
-#####
+# ####
 # Compare databases by looking at how GG classifies the FW representative sequences
 }else if (final.or.database == "database"){
-#####
+# ####
   cat("\n\ndoing database comparison\n\n")
   
   fw.percents <- import.FW.names(FilePath = fw.plus.gg.tax.file.path)
@@ -445,10 +445,10 @@ if (final.or.database == "final" | final.or.database == "Final" | final.or.datab
 
   
 
-#####
+# ####
 # Look at how bad it'd be if you used only the custom database instead of the workflow
 }else if (final.or.database == "forcing"){
-#####  
+# ####  
   cat("\n\nexamining how the custom database would have classified the dissimilar sequences that didn't belong in it \n(i.e. good thing you used my workflow!)\n\n")
   
   fw.percents <- import.FW.names(FilePath = fw.plus.gg.tax.file.path)
@@ -499,10 +499,10 @@ if (final.or.database == "final" | final.or.database == "Final" | final.or.datab
   export.summary.stats(SummaryVector = num.mismatches, FW_seqs = fw.gg.only, ALL_seqs = fw.percents, FolderPath = results.folder.path)
 
   
-##### 
+# #### 
 # Only compare the classifications made by the fw database to the gg classifications, not full tax tables
 }else{
-#####  
+# ####  
   cat("\n\ncomparing seqIDs the workflow classified with custom database to how general database would have classified them.\n\n")
   
   fw.percents <- import.FW.names(FilePath = fw.plus.gg.tax.file.path)


### PR DESCRIPTION
Since I fixed the FW database to have "unclassified" instead of blank spaces, the final taxonomy table was getting some names of, for example, "unclassified(82)" instead of just "unclassified.

I fixed this so that all unclassified names don't have any bootstrap value next to them.  This includes the, for example, "o__(98)" being changed to "unclassified" also.

I talked to Trina a while back and we couldn't think of any good reason to include those numbers for unclassified entries.
