### PR TITLE
Edits to Directions, Split out the database curation steps

### DIFF
--- a/Clean workflow
+++ b/Clean workflow
@@ -15,7 +15,7 @@ Summary of Steps and Commands (all commands entered in terminal window):
 		mv EndLineSemicolons general.taxonomy
 		rm NoSpaces
 
-NOTE: steps 1-14 can be run in a block using the bash script LazyRun.sh.  to source type in the terminal:
+NOTE: steps 1-13 can be run in a block using the bash script LazyRun.sh.  to source type in the terminal:
 	./LazyRun.sh
 		
 1. make BLAST database file (blast)
@@ -55,32 +55,26 @@ NOTE: steps 1-14 can be run in a block using the bash script LazyRun.sh.  to sou
 	mothur "#classify.seqs(fasta=otus.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
 	cat otus.general.wang.taxonomy > otus.general.taxonomy
 
-11. compare custom and general databases (mothur, bash)
-	mothur "#classify.seqs(fasta=custom.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
-	cat custom.general.wang.taxonomy > custom.general.taxonomy
+10.5 OPTIONAL database improvement check, see database improvement workflow step 10.5
 
-12. reformat taxonomy files (bash)
+11. reformat taxonomy files (bash)
 	sed 's/[[:blank:]]/\;/' <otus.98.taxonomy >otus.98.taxonomy.reformatted
 	mv otus.98.taxonomy.reformatted otus.98.taxonomy
 	sed 's/[[:blank:]]/\;/' <otus.general.taxonomy >otus.general.taxonomy.reformatted
 	mv otus.general.taxonomy.reformatted otus.general.taxonomy
-	sed 's/[[:blank:]]/\;/' <custom.general.taxonomy >custom.general.taxonomy.reformatted
-	mv custom.general.taxonomy.reformatted custom.general.taxonomy
-	sed 's/[[:blank:]]/\;/' <custom.taxonomy >custom.custom.taxonomy
 	
-13. compare taxonomy files (R)
+12. compare taxonomy files (R)
 	mkdir conflicts_98
 	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 85 70
-	mkdir conflicts_database
-	Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA NA 70 database 
+	
 
-14. choose appropriate pident cutoff (R)
-	Rscript plot_classification_disagreements.R otus.abund plots conflicts_database regular NA conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
+13. choose appropriate pident cutoff (R)
+	Rscript plot_classification_disagreements.R otus.abund plots regular NA conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
 
-15. generate final taxonomy file (R)
-	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 85 70 final
+14. generate final taxonomy file (R)
+	Rscript find_classification_disagreements.R otus.98.taxonomy NA ids.above.98 conflicts_98 98 85 70 final
 
-16. OPTIONAL: plot benefits of using this workflow (R)
+15. OPTIONAL: plot benefits of using this workflow (R)
 	Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.pvalues total.reads.per.seqID.csv plots
 	mothur "#classify.seqs(fasta=otus.fasta, template=custom.fasta, taxonomy=custom.taxonomy, method=wang, probs=T, processors=2)"
 	cat otus.custom.wang.taxonomy > otus.custom.taxonomy
@@ -90,7 +84,7 @@ NOTE: steps 1-14 can be run in a block using the bash script LazyRun.sh.  to sou
 	Rscript find_classification_disagreements.R otus.custom.taxonomy otus.98.85.70.taxonomy ids.above.98 conflicts_forcing NA 85 70 forcing
 	Rscript plot_classification_disagreements.R NA plots NA conflicts_forcing otus.custom.85.taxonomy
 
-17. tidy up (bash)
+16. tidy up (bash)
 	rm custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy otus.general.taxonomy otus.custom.taxonomy custom.general* otus.custom.[0-9]* *pvalues total*
 	mkdir scripts ; mv *.py *.R *.sh scripts
 	mkdir analysis ; mv conflicts* plots analysis
@@ -423,7 +417,7 @@ RScript plot_blast_hit_stats.R otus.custom.blast.table.modified 98 plots
 What mkdir command does:
 	mkdir		stands for "make directory", this creates a new folder
 	plots		the name of the new folder you are creating
-				this is where step 5 and step 14 will save plots generated for checking the cutoff
+				this is where step 5 and step 13 will save plots generated for checking the cutoff
 
 What each argument in the RScript is (keep in order and separate with a space):
 	RScript								sources an R script and allows it to accept arguments from the command line
@@ -589,7 +583,7 @@ NOTE: these bootstrap percent confidence values are NOT the confidence that the 
 assignment is *correct*, just that it is *repeatable* in that database.  This is another 
 paremeter that we could explore changing more in the future.  It likely should be different
 in the different databases also because of the different database sizes.  I left cutoff out
-in this command so that you can explore the different results of it later, in steps 13-14.
+in this command so that you can explore the different results of it later, in steps 12-13.
 
 
 __________________________________________________________________________________________
@@ -616,7 +610,7 @@ What the filenames are:
 
 __________________________________________________________________________________________
 
-Steps 10-14 are an optional check.
+Steps 10-13 are an optional check.
 __________________________________________________________________________________________
 
 10. assign taxonomy with general database only (mothur, bash)
@@ -653,7 +647,7 @@ ________________________________________________________________________________
 11. assign taxonomy to custom database with general database (mothur, bash)
 
 This allows you to compare your two databases to get an idea of the baseline level of 
-disagreement you can expect from their taxonomy classifications.  Also, in step 13 you
+disagreement you can expect from their taxonomy classifications.  Also, in step 12 you
 will generate a list of these disagreements that you can use to update your custom
 database classifications to better match your general database, if desired.  When you 
 choose an appropriate pident cutoff the goal is to avoid forcing OTUs into the custom
@@ -680,9 +674,9 @@ What the filenames are:
 	
 __________________________________________________________________________________________
 
-12. reformat taxonomy files (bash)
+11. reformat taxonomy files (bash)
 
-The R script in step 13 requires semicolon delimited taxonomy files.  The mothur output
+The R script in step 12 requires semicolon delimited taxonomy files.  The mothur output
 .taxonomy files are delimited with both tabs and semicolons.
 
 Reformat both files you will compare:
@@ -698,9 +692,7 @@ sed 's/[[:blank:]]/\;/' <otus.98.taxonomy >otus.98.taxonomy.reformatted
 mv otus.98.taxonomy.reformatted otus.98.taxonomy
 sed 's/[[:blank:]]/\;/' <otus.general.taxonomy >otus.general.taxonomy.reformatted
 mv otus.general.taxonomy.reformatted otus.general.taxonomy
-sed 's/[[:blank:]]/\;/' <custom.general.taxonomy >custom.general.taxonomy.reformatted
-mv custom.general.taxonomy.reformatted custom.general.taxonomy
-sed 's/[[:blank:]]/\;/' <custom.taxonomy >custom.custom.taxonomy
+
 
 Syntax of commands and what each argument does:
 	sed 's/find/replace/ <input >output
@@ -720,7 +712,7 @@ Syntax of commands and what each argument does:
 
 __________________________________________________________________________________________
 
-13. compare taxonomy files (bash, R)
+12. compare taxonomy files (bash, R)
 
 The R script find_classification_disagreements.R  creates a folder containing a file for 
 each upper taxonomic level (kingdom, phylum, class, order, lineage) that lists all of the 
@@ -754,8 +746,6 @@ Full Two Commands (type in terminal):
 
 mkdir conflicts_98
 Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 85 70
-mkdir conflicts_database
-Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA NA 70 database 
 
 Note: you must enter all the arguments in this order.
 
@@ -784,7 +774,7 @@ What the arguments are the second time you source the script:
 1.	Rscript									this opens R to accept arguments from the command line
 2.	find_classification_disagreements.R		this is the R script you're sourcing
 3.	custom.custom.taxonomy					this is the path to your custom taxonomy database 
-											after re-formatting it in step 12.
+											after re-formatting it in step 11.
 4.	custom.general.taxonomy					this is the path to your custom taxonomy database
 											classified using the general database in step 11.
 5.	NA										NA is typed as a placeholder here
@@ -811,15 +801,15 @@ What the generated files in your conflicts folders are:
 
 __________________________________________________________________________________________
 
-14. choose appropriate pident cutoff (R)
+13. choose appropriate pident cutoff (R)
 
 This step generates some plots that you can use to double check that your chosen cutoff is 
 appropriate.  The plots are saved into the "plots" folder that you created in step 5.  In
-order to examine the cutoff sensitivity, you may want to run steps 4-9 & 12-14 multiple times
+order to examine the cutoff sensitivity, you may want to run steps 4-9 & 11-13 multiple times
 with different pident cutoffs.  Note that the slowest step, classify.seqs() in mothur, will
 be much faster because the mothur database files are not re-made.
 
-Rscript plot_classification_disagreements.R otus.abund plots conflicts_database regular regular conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
+Rscript plot_classification_disagreements.R otus.abund plots regular regular conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
 
 What the arguments are:
 1.		Rscript									Calls program R in a way that accepts command line arguments
@@ -829,12 +819,12 @@ What the arguments are:
 												note: this folder must already exist. you made it in step 5.
 5.		conflicts_database						path to folder containing taxonomy disagreements between
 												the custom and the general database.
-												You made this folder in step 13.
+												You made this folder in step 12.
 6.		regular									placeholder, this is only used in the step where you plot forcing
 7.		regular									also placeholder. Note: these must say "regular" though.
 6.		conflicts_94							path to folder containing taxonomy disagreements between
 												this cutom+general workflow and the general database alone.
-												You made this folder in step 13.
+												You made this folder in step 12.
 7.		ids.above.94							path to the file that lists all the seqIDs meeting your
 												pident cutoff that were therefore classified with your
 												custom databse. You made this file in step 4.
@@ -852,15 +842,15 @@ What the generated plots are:
 
 __________________________________________________________________________________________
 
-15. generate final taxonomy file (R)
+14. generate final taxonomy file (R)
 
-Based on your results from step 14, choose which pident cutoff to use.  Use the same script 
-from step 13, except this time specify "final."  This final taxonomy file is different from 
+Based on your results from step 13, choose which pident cutoff to use.  Use the same script 
+from step 12, except this time specify "final."  This final taxonomy file is different from 
 files created in step 9 because it applies your clustering bootstrap pvalue cutoff, calling
 everything below that cutoff "unclassified."  
 
 Recall that choosing that cutoff was left out of the mothur command to allow flexibility in
-analyzing results.  The "final" argument to this script is left out in step 13 because it takes
+analyzing results.  The "final" argument to this script is left out in step 12 because it takes
 longer when it is included.  This is because in finding the classification disagreements, the
 script only compares classifications assigned by the custom database, which is a small subset 
 of all of the classifications.
@@ -895,15 +885,15 @@ What the arguments are this (3rd) time you source the script:
 
 __________________________________________________________________________________________
 
-16. OPTIONAL: plot benefits of using this workflow (R)
+15. OPTIONAL: plot benefits of using this workflow (R)
 
-16.a Plot improvement over using general database alone
+15.a Plot improvement over using general database alone
 
 In this step two plots are generated that show you the benefit of using the custom workflow.
 The plots show the number of known taxonomic assignments by either % of total OTUs or % of 
 total reads.  Basically, the script sums up everything that is not called "unclassified"
 in the final workflow taxonomy file and the general database taxonomy file with the bootstrap
-p-value cutoffs applied.  These files are both generated in step 15.
+p-value cutoffs applied.  These files are both generated in step 14.
 
 Full Command (Type into terminal):
 
@@ -911,23 +901,23 @@ Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.p
 
 What the arguments are:
 	final.taxonomy.pvalues			a file of p-values corresponding to the final taxonomy file you
-									generated in step 15.  This file, with this name, was automatically
-									generated in step 15 so it is already in your working directory.
+									generated in step 14.  This file, with this name, was automatically
+									generated in step 14 so it is already in your working directory.
 	final.general.pvalues 			a file of p-values corresponding to the general-classified taxonomy
 									after the classification p-value cutoff has been applied. This file,
-									with this name, was automatically generated in step 15 so it is already
+									with this name, was automatically generated in step 14 so it is already
 									in your working directory.
 	total.reads.per.seqID			a file that lists each seqID and the total number of reads for that
 									seqID.  This file, with this name, was automatically generated in
-									step 14, using your otus.abund table, so it is already in your 
+									step 13, using your otus.abund table, so it is already in your 
 									working directory.
 	plots							the name of the folder that plots are saved into.  you created this
 									folder in step 5.
 
-16.b Plot folly of using custom database alone
+15.b Plot folly of using custom database alone
 
 In this step the classifications you get using the custom database alone are compared to the final workflow
-taxonomy file generated in step 15.  The plots created show the "forcing" that would occur from using only
+taxonomy file generated in step 14.  The plots created show the "forcing" that would occur from using only
 the small database.  Forcing occurs because the RDP classifier classifies sequences stochastically, putting
 them with the most similar sequence *in your database*.  If there are no similar sequences and the database is 
 large, then the sequence will be put somewhere different each time, end up with a low p-value, and be called
@@ -950,7 +940,7 @@ Rscript plot_classification_disagreements.R otus.abund plots NA conflicts_forcin
 									
 __________________________________________________________________________________________
 
-17. tidy up (bash)
+16. tidy up (bash)
 
 This step tidies up your working directory folder by removing intermediate files you don't 
 need anymore and moving remaining files into orgainized folders.
@@ -958,7 +948,7 @@ Note: these bash commands only work if you've been using the same names as the w
 Note: go through these commands in order.
 
 
-17.1 remove intermediate files
+16.1 remove intermediate files
 
 Full Command (Type in Terminal):
 
@@ -980,7 +970,7 @@ otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy otus.general.taxonomy otu
 				the classifications at different pident cutoffs and from general and custom alone and the database comparison
 				note: these files don't have p-value cutoffs applied (i.e. nothing's called unclassified). 
 				If you want to save files like these for additional analysis, 
-					re-run step 15 to get additional "final" versions.
+					re-run step 14 to get additional "final" versions.
 					re-run step 10 with an additional "cutoff=" flag.
 *pvalues total*	These are files generated to use in the plot improvement script
 
@@ -992,7 +982,7 @@ mkdir intermediate
 mv custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy *.general.taxonomy intermediate/
 
 
-17.2 move scripts into scripts folder
+16.2 move scripts into scripts folder
 
 Full 2 commands (Type in Terminal):
 
@@ -1002,7 +992,7 @@ mv *.py *.R *.sh scripts/
 Note: I recommend saving all the script versions you used to create your data so you could reproduce it.
 
 
-17.3 save files used in analyzing your results in analysis folder
+16.3 save files used in analyzing your results in analysis folder
 
 Full 2 commands (Type in Terminal):
 
@@ -1013,7 +1003,7 @@ Note: You can delete this instead if you're all done analyzing. Instead of the t
 
 rm -r conflicts* plots/
 
-17.4 save your actual data files in a folder called data
+16.4 save your actual data files in a folder called data
 
 Full Two commands (Type in Terminal):
 
@@ -1023,7 +1013,7 @@ mv otus* data/
 Note: Yeyy!  This is what you're gonna use to actually do stuff now!!
 
 
-17.5 save the version of the taxonomy databases you used in a databases folder
+16.5 save the version of the taxonomy databases you used in a databases folder
 
 Full Two Commands (type in terminal):
 

--- a/Clean workflow
+++ b/Clean workflow
@@ -176,9 +176,20 @@ and rename them to match the above names so that you can copy and paste commands
 Also put the script files in this workflow into that same folder.
 Then make that folder your working directory for the entirety of this workflow.
 
-Reformat your files so that:
+I. General notes on the seqIDs in all files:
 
-1. .taxonomy files: 
+OTU seqID's:
+			-cannot contain any whitespace
+			 BLAST will call some parts the seqID and some parts comments if they're separated.
+			 Having BLAST seqIDs that don't match the full >comment line of the fasta file will 
+		 	 throw off the python script that creates fasta files for the chosen seqIDs in step 8.
+		 	 -must match between the otus.fasta file and the otus.abund file,
+			 though consistent ordering is not necessary.
+
+
+II. Taxonomy Database Files:
+
+	1. .taxonomy files: 
 		-must be compatible with mothur, example format:
 		
 			seqID tab kingdom;phylum;class;order;family;genus;species;
@@ -189,12 +200,12 @@ Reformat your files so that:
 		
 		-If you are using the Green Genes taxonomy database, you can reformat it this way: 
 
-Full 4 Commands (type in terminal) when general.taxonomy is the green genes taxonomy file:
+	Full 4 Commands (type in terminal) when general.taxonomy is the green genes taxonomy file:
 
-sed 's/ //g' <general.taxonomy >NoSpaces
-sed 's/$/;/' <NoSpaces >EndLineSemicolons
-mv EndLineSemicolons general.taxonomy
-rm NoSpaces
+	sed 's/ //g' <general.taxonomy >NoSpaces
+	sed 's/$/;/' <NoSpaces >EndLineSemicolons
+	mv EndLineSemicolons general.taxonomy
+	rm NoSpaces
 
 			Syntax of commands and what each argument does:
 				sed 's/find/replace/ <input >output
@@ -216,30 +227,50 @@ rm NoSpaces
 					rm		this removes (aka deletes) the file named filename
 		
 
-			-If you are using the Silva database... no fucking clue, what does this look like??
+			-If you are using the Silva database... ***add formatting advice***
 			*************
 
-2. OTU seqID's:
-			-must match between the otus.fasta file and the otus.abund file,
-			 though consistent ordering is not necessary.
-			-cannot contain any whitespace
-			 BLAST will call some parts the seqID and some parts comments if they're separated.
-			 Having BLAST seqIDs that don't match the full >comment line of the fasta file will 
-		 	 throw off the python script that finds the chosen sequences.
-
-3. OTU files:
-		-format of the OTU table otus.abund is tab delimited, seqIDs in 1st column, abundances in rest of columns:
-			seqID	Abundance	Abundance	Abundance	Abundance
-			seqID	Abundance	Abundance	Abundance	Abundance
-			seqID	Abundance	Abundance	Abundance	Abundance
+	2. .fasta files:
+		-these should be in fasta format (note the carrot before the seqID, a new line 
+		separateing seqID from sequence, sequence can be one line or multiple lines.)
 		
+		>seqID
+		TACGTAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAG
+		>seqID
+		TACGTAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAG
+		
+II. Your OTU files:
 		-QC of your OTU sequences should be performed before you start assigning taxonomy.
+		 if you start using mothur, and start this workflow right before the first classify.seqs() command
+		 if you start using qiime ****where do you start there??**
+
+	1. .fasta file:
+		- same format as the taxonomy database fasta files, above.
 		
-		If you did QC in mothur, the starting files are called:
-		***************
+		- if you're using mothur, this file is called:
+		stability.trim.contigs.good.unique.good.filter.unique.precluster.pick.fasta
 		
-		If you did QC in qiime, the starting files are called:
-		***************
+		- if you're using qiime, this file is called:
+		*****look up qiime***
+		
+		to format the mothur file:
+
+	2. .abund file:
+		- this is the table of relative abundances for each OTU in each sample, 
+		 aka your OTU table.
+		 
+		-format is tab delimited, seqIDs in 1st column, abundances in rest of columns:
+			seqID	Abundance	Abundance	Abundance	Abundance
+			seqID	Abundance	Abundance	Abundance	Abundance
+			seqID	Abundance	Abundance	Abundance	Abundance
+		
+		
+		- If you're using mothur, this file is called:
+		***fill this in!!!***
+		
+		-If you're using qiime, this file is called:
+		****check on this***
+		
 		
 __________________________________________________________________________________________
 

--- a/Clean workflow
+++ b/Clean workflow
@@ -462,67 +462,63 @@ the evalue statistics, see: http://www.ncbi.nlm.nih.gov/BLAST/tutorial/Altschul-
 
 The python script find_seqIDs_blast_removed.py is used to find all of the 
 sequence IDs in the original fasta file that do not appear in the blast output.  The python 
-script then creates a new file in the same format as step 4's R script output file that
+script then creates a new file in the same format as step 5's R script output file that
 is a newline-delimited list of the missing sequence IDs.
 
 The bash command cat concatenates these missing ids with the ids below the chosen cutoff
 pident.  That is because the ids blast didn't report hits for had even worse pidents than 
-the ones that didn't make the R script cutoff.
+the ones that didn't make the R script cutoff, so they belong in the set that will be 
+classified by the general database.
 
-Full Command (type in terminal):
+Full Two Commands (type in terminal):
 
 python find_seqIDs_blast_removed.py otus.fasta otus.custom.blast.table.modified ids.missing
 cat ids.below.98 ids.missing > ids.below.98.all
-
-These arguments in the python script must be in the correct order.
-python sources the .py script using the arguments supplied after it in the terminal.
-Separate all arguments with a space.
-
-What each argument is- 1st command (python):
-	1st: script.py		path to this script. The script is called find_seqIDs_blast_removed.py
-	2nd: fastafile		path to the fasta file containing all the seqIDs
-	3rd: blastfile		path to the blast results in table format (col1 = seqID)				
-	4th: outputfile		path to the file with \n delimited seqIDs the script adds to
 						
-What each file is:
+What each argument is in python script:
+	python							opens the python program to source the script
 	find_seqIDs_blast_removed.py	python script you're sourcing
-	otus.fasta						original fasta file of your sequences from step 0
-	otus.FW.blast.table.modified	reformatted blast results from step 4
-	ids.below.98					seqIDs below your cutoff from R script in step 4 
-									that the missing ones are added to in this step.
+	otus.fasta						original fasta file of your sequences from step 0,
+									this contains all the seqIDs
+	otus.FW.blast.table.modified	reformatted blast results from step 4,
+									this contains all the seqIDs reported by BLAST
+	ids.missing						the output file of seqIDs that were left out of BLAST
+									results.  Its format is new line delimited seqIDs, no header
+	
+What each argument in the bash script is:
+	cat								function that concatenates two files
+	ids.below.98					seqIDs below your cutoff from R script in step 5.
+	ids.missing						seqIDs not returned by BLAST, from this step, above.
+	> ids.below.98.all				combine those two files into this new one.
+									this now contains all the seqIDs you will classify in
+									the general taxonomy database, in \n delimited format.
 									
-
 __________________________________________________________________________________________
 
 8. create fasta files of desired sequence IDs (python)
 
-The create_fastas_given_seqIDs.py takes the sequence IDs selected from the blast output 
+The create_fastas_given_seqIDs.py takes the sequence IDs selected using the blast output 
 and finds them in the original query fasta file.  
 It then creates a new fasta file containing just the desired sequences.
+The script is run twice, first to create the fasta file for seqIDs above the pident cutoff,
+second to create the fasta file for seqIDs below the pident cutoff.  The fasta files will 
+be classified with the custom and general databases, respectively.
 
 Full Two Commands (type in terminal):
 
 python create_fastas_given_seqIDs.py ids.above.98 otus.fasta otus.above.98.fasta
 python create_fastas_given_seqIDs.py ids.below.98.all otus.fasta otus.below.98.fasta
 
-These arguments must be in the correct order.
-python sources the .py script using the arguments supplied after it in the terminal.
-Separate all arguments with a space.
-
 What each argument is:
-	1st: script.py	the path to this script. The script is called create_fastas_given_seqIDs.py
-	2nd: idfile		the path to the file with \n separated seqIDs that was generated in step 4
-	3rd: fastafile	the path to the otu fasta file containing all the seqIDs from step 0
-	4th: outputfile the path to the new fasta file the script generates
-					NOTE: if this file already exist the script will delete it before starting.
-
-What each file is:
+	python							opens the python program to souce the script
 	create_fastas_given_seqIDs.py	the python script you're sourcing 
-	ids.above.98					the file of seqIDs at or above your cutoff from step 4
-	ids.below.98.all				the file of all seqIDs below your cutoff from step 6
-	otus.fasta						the original fasta file of your otu sequences
+	ids.above.98					the file of seqIDs at or above your cutoff from step 5
+	ids.below.98.all				the file of all seqIDs below your cutoff from step 7
+	otus.fasta						the original fasta file of all your OTU sequences from step 0
 	otus.above.98.fasta				the output file with fasta sequences at or above your cutoff
 	otus.below.98.fasta				the output file with fasta sequences below your cutoff
+									NOTE: if this output file already exist the script will 
+									delete it before starting.
 	
 __________________________________________________________________________________________
 

--- a/Clean workflow
+++ b/Clean workflow
@@ -15,7 +15,7 @@ Summary of Steps and Commands (all commands entered in terminal window):
 		mv EndLineSemicolons general.taxonomy
 		rm NoSpaces
 
-NOTE: steps 1-13 can be run in a block using the bash script LazyRun.sh.  to source type in the terminal:
+NOTE: steps 1-14 can be run in a block using the bash script LazyRun.sh.  to source type in the terminal:
 	./LazyRun.sh
 		
 1. make BLAST database file (blast)
@@ -27,54 +27,56 @@ NOTE: steps 1-13 can be run in a block using the bash script LazyRun.sh.  to sou
 3. reformat blast results (blast)
 	blast_formatter -archive otus.custom.blast -outfmt "6 qseqid pident length qlen qstart qend" -out otus.custom.blast.table
 
-4. filter BLAST results (R)
+4. correct BLAST pident (R)
 	Rscript calc_full_length_pident.R otus.custom.blast.table otus.custom.blast.table.modified
+
+5. filter BLAST results (R)
 	Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.above.98 98 TRUE 
 	Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.below.98 98 FALSE
 
-5. check that BLAST settings are appropriate (R)
+6. check that BLAST settings are appropriate (R)
 	mkdir plots
 	RScript plot_blast_hit_stats.R otus.custom.blast.table.modified 98 plots
 
-6. recover sequence IDs left out of blast (python, bash)
+7. recover sequence IDs left out of blast (python, bash)
 	python find_seqIDs_blast_removed.py otus.fasta otus.custom.blast.table.modified ids.missing
 	cat ids.below.98 ids.missing > ids.below.98.all
 	
-7. create fasta files of desired sequence IDs (python)
+8. create fasta files of desired sequence IDs (python)
 	python create_fastas_given_seqIDs.py ids.above.98 otus.fasta otus.above.98.fasta
 	python create_fastas_given_seqIDs.py ids.below.98.all otus.fasta otus.below.98.fasta
 
-8. assign taxonomy (mothur)
+9. assign taxonomy (mothur)
 	mothur "#classify.seqs(fasta=otus.above.98.fasta, template=custom.fasta,  taxonomy=custom.taxonomy, method=wang, probs=T, processors=2)"
 	mothur "#classify.seqs(fasta=otus.below.98.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
 
-9. combine taxonomy files (terminal)
+10. combine taxonomy files (terminal)
 	cat otus.above.98.custom.wang.taxonomy otus.below.98.general.wang.taxonomy > otus.98.taxonomy
 
-10. assign taxonomy with general database only (mothur, bash)
+11. assign taxonomy with general database only (mothur, bash)
 	mothur "#classify.seqs(fasta=otus.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
 	cat otus.general.wang.taxonomy > otus.general.taxonomy
 
-10.5 OPTIONAL database improvement check, see database improvement workflow step 10.5
+11.5 OPTIONAL database improvement check, see database improvement workflow step 11.5
 
-11. reformat taxonomy files (bash)
+12. reformat taxonomy files (bash)
 	sed 's/[[:blank:]]/\;/' <otus.98.taxonomy >otus.98.taxonomy.reformatted
 	mv otus.98.taxonomy.reformatted otus.98.taxonomy
 	sed 's/[[:blank:]]/\;/' <otus.general.taxonomy >otus.general.taxonomy.reformatted
 	mv otus.general.taxonomy.reformatted otus.general.taxonomy
 	
-12. compare taxonomy files (R)
+13. compare taxonomy files (R)
 	mkdir conflicts_98
 	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 85 70
 	
 
-13. choose appropriate pident cutoff (R)
+14. choose appropriate pident cutoff (R)
 	Rscript plot_classification_disagreements.R otus.abund plots regular NA conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
 
-14. generate final taxonomy file (R)
+15. generate final taxonomy file (R)
 	Rscript find_classification_disagreements.R otus.98.taxonomy NA ids.above.98 conflicts_98 98 85 70 final
 
-15. OPTIONAL: plot benefits of using this workflow (R)
+16. OPTIONAL: plot benefits of using this workflow (R)
 	Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.pvalues total.reads.per.seqID.csv plots
 	mothur "#classify.seqs(fasta=otus.fasta, template=custom.fasta, taxonomy=custom.taxonomy, method=wang, probs=T, processors=2)"
 	cat otus.custom.wang.taxonomy > otus.custom.taxonomy
@@ -84,7 +86,7 @@ NOTE: steps 1-13 can be run in a block using the bash script LazyRun.sh.  to sou
 	Rscript find_classification_disagreements.R otus.custom.taxonomy otus.98.85.70.taxonomy ids.above.98 conflicts_forcing NA 85 70 forcing
 	Rscript plot_classification_disagreements.R NA plots NA conflicts_forcing otus.custom.85.taxonomy
 
-16. tidy up (bash)
+17. tidy up (bash)
 	rm custom.db.* custom.8mer custom.custom* custom.tree* general.8mer general.general* general.tree* *wang* mothur.*.logfile otus.custom.blast* ids* otus.below*.fasta otus.above*.fasta otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy otus.general.taxonomy otus.custom.taxonomy custom.general* otus.custom.[0-9]* *pvalues total*
 	mkdir scripts ; mv *.py *.R *.sh scripts
 	mkdir analysis ; mv conflicts* plots analysis
@@ -253,23 +255,20 @@ Full Command (type in terminal):
 
 makeblastdb -dbtype nucl -in custom.fasta -input_type fasta -parse_seqids -out custom.db
 
-What the filenames are:
-	custom.fasta		this is the path to the small custom taxonomy file you want to use to assign
-						taxonomy before using a larger taxonomy database
-						(i.e. the freshwater taxonomy database fasta file)
-						note: if the file path has spaces in it it needs to be ' "/path/double quoted" '
-	custom.db			this is the name you choose for the blast database you are creating.
-						It makes 6 files with different final extensions, but all start with this.  
-						Default is your -in file name with those extensions, but it's
-						less confusing to add .db so you know what the weird extension files are
-What each flag does:
+What each argument is:
 	-dbtype nucl		a required argument, says the database input file is nucleic acids (nucl)
-	-in custom.fasta	specify path of the input file that it makes the database out of
-	-input_type fasta	tells it the input file is a fasta file (that's the default value too)
+	-in custom.fasta	specify path of the input file that it makes the database out of.
+						this is the path to the small custom taxonomy file you want to use 
+						(i.e. the freshwater taxonomy database fasta file)
+						note: if the file path has spaces in it, it needs to be ' "/path/double quoted" '
+	-input_type fasta	specifies the input file is a fasta file (that's the default value too)
 	-parse_seqids		this tells it to include information in the database that will later
 						allow you to pull sequences back out of it.  
 						This is necessary for using blast_formatter later.
-	-out custom.db		specify path of the database files this command created  
+	-out custom.db		specify path of the database files this command creats. BLAST makes 6 files 
+						with different extensions, but they all start with this.  BLAST Default is your 
+						-in file name with those extensions, but it's less confusing to add .db so you 
+						can easily identify what each file is.  
 
 These 6 files are created:
 	custom.db.nhr
@@ -277,7 +276,7 @@ These 6 files are created:
 	custom.db.nsd
 	custom.db.nsi
 	custom.db.nsq
-but later when you tell it which database file to use you just say custom.db and it figures the rest out
+(but later when you tell BLAST which database file to use you just say custom.db and it figures the rest out)
 
 __________________________________________________________________________________________
 
@@ -286,55 +285,48 @@ ________________________________________________________________________________
 Use the command blastn to run a megablast that returns the best hit in the taxonomy database (subject)
 for each of your OTU sequences (queries). Megablast is optimized for finding very similar matches with
 sequences longer than 30 bp.  This workflow was made for ~100 bp sequences and may need to be re-optimized
-for sequences of different lengths.
+for sequences of different lengths.  You check if settings are appropriate in step 6.
 
 Full Command (type in terminal):
 
 blastn -query otus.fasta -task megablast -db custom.db -out otus.custom.blast -outfmt 11 -max_target_seqs 5
 
-What the filenames are:
-	otus.fasta				the query file. the fasta file of your OTU sequences you want classified
-							this is what you reformatted in step 0.
-	custom.db				the subject file. the blast database file you made from the taxonomy 
-							database fasta sequences in step 1.
-	otus.custom.blast		the BLAST output file. Its format is unreadable by you,
-							but it's the detailed BLAST format that blast_formatter accepts.
-							filename example here is query.subject.blast 
-
-What each flag does:						
-	-query otus.fasta 		specify path of query file
+What each argument is:						
+	-query otus.fasta 		specify path of query file, otus.fasta.  This is the fasta file of your OTU 
+							sequences you want classified that you reformatted in step 0.
 	-task megablast 		this is already optimized by smart BLAST people for high similarity hits.
 							It is also the blastn default task. for more info see 
 							http://www.ncbi.nlm.nih.gov/Class/MLACourse/Modules/BLAST/nucleotide_blast.html
-	-db custom.db 			the name of the blast database created previously (without the additional file extensions)
-	-out otus.custom.blast	specify path of the blast output file (this is the file you're creating)
+	-db custom.db 			the name of the blast database created in step 1(without the additional file extensions)
+							This database is made from your subject sequences, the small, custom taxonomy database
+	-out otus.custom.blast	specify path of the blast output file (this is the file you're creating). Its format 
+							is unreadable by you, but it's the detailed BLAST format that blast_formatter accepts.
+							The filename here describes query.subject.blast
 	-outfmt 11 				need this format in order to use blast_formatter command
 	-max_target_seqs 5		only keep the best 5 hits for each query sequence
-							you will compare how good these are to check if BLAST settings are appropriate in step 5
-							you can choose more or less target seqs if you want to.
+							you will compare how good these are to check if BLAST settings are appropriate in step 6
+							you can choose more or less target seqs if you want to, it doesn't have a huge impact on speed.
 
 __________________________________________________________________________________________
 
 3. reformat BLAST results (blast)
 
-The blast_formatter function in blast takes the full outformat 11 file and reformats it to any other
+The blast_formatter function in blast takes the outformat 11 file and reformats it to any other
 possible format.  Here we reformat to a custom table format to feed into the R script the pulls out
 matching and nonmatching sequence IDs.
-However, using blast_formatter you can look at your blast results from the previous step any way you'd like.
+However, using blast_formatter you can look at your blast results from the previous step any way you'd like!
+Just keep in mind, things like "length" have different definitions in different output formats (yeah. really.), 
+so pay careful attention if you try to re-do calculations on your own.
 
 Full Command (type in terminal):
 
 blast_formatter -archive otus.custom.blast -outfmt "6 qseqid pident length qlen qstart qend" -out otus.custom.blast.table
 
-What the filenames are:
-	otus.custom.blast			The blast result file generated in step 2. This is in the ASN.1 blast file format.
-	otus.custom.blast.table		The blast result reformatted into a 6 column table that the R script accepts.
-								The tab-delimited columns are: qseqid pident length qlen qstart qend
-
-What each flag does:		
-	-archive otus.custom.blast 		Specify path to the blast result file you are reformatting
+What each argument is:		
+	-archive otus.custom.blast 		Specify path to the blast result file you are reformatting.
+									This was generated in step 2, it is in the ASN.1 blast file format.
 	-outfmt "6 qseqid pident length qlen qstart qend"	
-									6 is tabular format without headers or other info btwn rows of data, 
+									6 is a tabular format without headers or other info btwn rows of data, 
 									the rest specifies what goes in each tab-delimited column:
 										1 qseqid: query (OTU) sequence ID
 										2 pident: percent identity (# of matches / # "columns" in the sequence)
@@ -342,55 +334,70 @@ What each flag does:
 										4 qlen: full length of query sequence
 										5 qstart: index of beginning of alignment on query sequence
 										6 qend: index of end of alignment on query sequence
-	-out otus.custom.blast.table	Specify path to the output file of formatted blast results
+	-out otus.custom.blast.table	Specify path to the output file with above formatting.
 				
 __________________________________________________________________________________________
 
-4. filter BLAST results (R)
+4. correct BLAST pident (R)
 
-The filter_seqIDs_by_pident.R script takes the formatted blast file and 
-calculates a "true" pident value that corrects the pident value for the entire length of the query.
-I could not find any command that forces blast use the entire query sequence, so this is the workaround. 
-The "true" pident is a worst case scenario that assumes any edge gaps are mismatches.
+The calc_full_length_pident.R script takes the formatted blast file and calculates a 
+"full length" pident value that corrects the pident value for the entire length of the query.
+BLAST returns the "highest scoring pair", which is weighted by both similarity and length.
+However we are trying to compare the entire OTU sequence, not just a section of it that 
+matches really well.  I could not find any command that forces blast use the entire query 
+sequence, so this is the workaround. This "full length" pident is a conservative, worst case 
+scenario that assumes any edge gaps are mismatches.
 Calculation:
-	"true pident" = pident * length / (length - (qend - qstart) + qlen)
-The R script is run twice, once to generate the sequence ID's above/equal to the "true pident" 
-cutoff that are destined for taxonomy assignment in the small custom database, once to generate
-the sequence ID's below the "true pident" cutoff that are destined for taxonomy assignment
-in the large general database.
+	"full length pident" = pident * length / (length - (qend - qstart) + qlen)
+This script performs those calculations, and then checks which of the top 5 reported BLAST hits had
+the best corrected, full length pident.  It returns a similar, tab delimited output file that 
+includes the corrected full length pident and which BLAST hit number had the best corrected pident.
 
-Full Three Commands (type in terminal):
+Full Command (type in terminal):
 
 Rscript calc_full_length_pident.R otus.custom.blast.table otus.custom.blast.table.modified
-Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.above.98 98 TRUE 
-Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.below.98 98 FALSE
 
-These arguments must be in the correct order.
-Rscript sources the .R script using the arguments supplied after it in the terminal.
+
 Separate all arguments with a space.
 
 What each argument is:
-	1st: script.R	the path to this script.  The script is called filter_seqIDs_by_pident.R
-	2nd: blastfile	the path to the formatted blast file. This is the otus.custom.blast.table file from step 3
-	3rd: statsfile	the path to the modified blast table you create.  This is used in step 5 to analyze the BLAST settings.
-	4rd: outputfile	the path to the seqID file you are creating. This is the list of sequence ID's matching your criteria.
-	5th: cutoff#	the cutoff percent identity to use. Note this is the calculated "true" full length percent identity,
-					not necessarily the value blast returns for the match.  this is a number.
-	6th: matches	want matches? TRUE or FALSE. TRUE: return seqID's >= cutoff, FALSE: return seqID's < cutoff
-
-What each file is:
-	filter_seqIDs_by_pident.R			the r script.  source from the command line by typing
-										Rscript, not R.  Rscript accepts arguments after the script.
+	Rscript								sources the R script using the arguments supplied after it in the terminal.
+	calc_full_length_pident.R			the R script.
 	otus.custom.blast.table				the formatted blast output from step 3
-	otus.custom.blast.table.modified	the output file containing the modified BLAST hit table, used in step 5
-										note: this is the same regardless of the cutoff chosen
-	ids.above.98						the output file containing seqIDs at or above your cutoff value, used in step 7
-	ids.below.98						the output file containing seqIDs below your cutoff value, used in step 6
-										the format of these seqID output files are \n delimited seqIDs.
+	otus.custom.blast.table.modified	the output file containing the modified BLAST hit table, used in step 5.
+										It contains tab delimited columns without column names. They are:
+										qseqid, pident, length, qlen, q.align, true.pids, hit.num.best.ids
+
+__________________________________________________________________________________________
+
+5. filter BLAST results (R)
+
+This R script, filter_seqIDs_by_pident.R, is run twice. First to generate the sequence ID's 
+above/equal to the user specified "full length pident" cutoff.  Those sequence IDs are 
+destined for taxonomy assignment in the small custom database.  Second it is run to generate 
+the sequence ID's below the "full length pident" cutoff, which are destined for taxonomy 
+assignment in the large general database.
+
+Full Two Commands (type in terminal):
+
+Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.above.98 98 TRUE 
+Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.below.98 98 FALSE
+
+What each argument is:
+	Rscript								Sources the R script using the arguments supplied after it in the terminal.
+	filter_seqIDs_by_pident.R			The R script.  
+	otus.custom.blast.table.modified	the BLAST table with corrected, full length pident values created in step 4.
+	ids.above.98 						the output file containing seqIDs at or above your cutoff value, used in step 7
+	ids.below.98						the output file containing seqIDs below your cutoff value, used in step 7
+										the format of these seqID output files are \n delimited seqIDs, no header.
+	98									the full length pident cutoff you are using to decide which sequences belong
+										in which taxonomy database classification
+	TRUE								return seqID's >= cutoff
+	FALSE								return seqID's < cutoff
 	
 __________________________________________________________________________________________
 
-5. check that BLAST settings are appropriate (R)
+6. check that BLAST settings are appropriate (R)
 
 There is no way to force BLAST to return only full-length hits, it will always return the 
 best "High Scoring Pair (HSP)" it finds, based on it's scoring that weights both the quality
@@ -399,38 +406,41 @@ because the entire OTU sequences are matched to the reference 16S sequences when
 taxonomy.
 
 High pident short HSPs will be converted to low pident "full length" HSPs because all missing
-basepairs are considered a mismatch by my conservative script in step 4.  Therefore, if high 
-pident short HSPs are being reported by BLAST instead of lower pident long HSPs you could 
-get incorrect results.  However, the pident cutoff you will choose for taxonomy assignment 
+basepairs are considered a mismatch by my conservative calculation in step 4.  Therefore, some high 
+pident short HSPs are reported by BLAST instead of lower pident long HSPs. The true full length
+pident could have been higher than my conservative calculation from the BLAST pident that assumes
+all un-reported basepairs are mismatches.  If this is happening, then you might not include seqIDs
+in your custom classification that met your cutoff.  However, the pident cutoff for taxonomy assignment 
 using 16S sequences is pretty high, so while it's likely that some of the short BLAST HSPs
-may have longer HSPs with better full-length pidents, it's unlikely that any of those better
-ones would be good enough to meet your pident criteria. 
+may have longer HSPs with better full-length pidents, it's less likely that any of those better, 
+"true" pidents would be good enough to meet your pident criteria. 
 
-The likelihood of incorrect results because of BLAST chooseing HSPs that are too short increases
-as the length of your OTU sequences goes up.  This step tries to check if this might
+The likelihood of incorrect results because of BLAST choosing HSPs that are not full length increases
+as the length of your OTU sequences increases.  This step tries to check if this might
 be a problem.  Generate some plots with the R script plot_blast_hit_stats.R.
 
 Full Two Commands (type in the terminal)
 mkdir plots
 RScript plot_blast_hit_stats.R otus.custom.blast.table.modified 98 plots
 
-What mkdir command does:
+What mkdir bash command does:
 	mkdir		stands for "make directory", this creates a new folder
 	plots		the name of the new folder you are creating
-				this is where step 5 and step 13 will save plots generated for checking the cutoff
+				this is where step 6 and step 14 will save plots generated for checking the cutoff
 
-What each argument in the RScript is (keep in order and separate with a space):
+What each argument in the R script is:
 	RScript								sources an R script and allows it to accept arguments from the command line
 	plot_blast_hit_stats.R				the script you are sourcing
 	otus.custom.blast.table.modified	the modified blast table produced in step 4.
-	98									the pident cutoff used to create this BLAST table
+	98									the pident cutoff you chose to filter your sequences by
 	plots								the folder your generated plots will be saved in
 	https://cran.mtu.edu				this is an OPTIONAL argument for those who
 										1. don't have the "reshape" R package installed already
 										2. live far away from the midwestern USA
 										It's the web address to the cran mirror you use, choosing
 										one close to you could make it slightly faster but
-										this honestly doesn't matter much.   
+										this honestly doesn't matter much.  The script will automatically
+										install the reshape package temporarily if you don't have it already   
 
 What each generated file is:
 	BLAST_hits_line_plot.png
@@ -439,25 +449,10 @@ What each generated file is:
 	BLAST_hits_used_for_pidents_90-100.png
 	BLAST_hits_used_overall.png
 	
-*******fix all the file descriptions.  as in, add some descriptions of the plots.
-old description... my new description is not very good.  come back to this.
-
-are being chosen over lower %id longer HSPs that would have still 
-met %id cutoff.
-This is something that could be examined to decide if blastn custom scoring should be used instead of megablast.
-However, we are only keeping very similar sequences anyway, and these sequences are very short, and
-megablast is optimized with complicated statistics to find closely related sequences which we want. 
-The R script in step 4 will tell you alignment length vs. query length stats so keep an eye out for this.
-If many alignments are shorter then this should be examined more carefully.
-
-Note: You may need to choose a different "true pident" cutoff for your sequence data.
-I chose mine based on values that gave me classifications consistent to the class level 
-between the small and large databases. You can use a supplementary R script & workflow to 
-repeat this.  One thing that might affect this choice is the length of your sequences.
-
+****Choose which plots to keep*****
 __________________________________________________________________________________________
 
-6. recover sequence IDs left out of blast (python, bash)
+7. recover sequence IDs left out of blast (python, bash)
 
 Blast has a built in reporting cutoff based on evalue.  The blast expect value depends on
 the length of the hit and the size of the database, and it reflects how frequently you 
@@ -499,7 +494,7 @@ What each file is:
 
 __________________________________________________________________________________________
 
-7. create fasta files of desired sequence IDs (python)
+8. create fasta files of desired sequence IDs (python)
 
 The create_fastas_given_seqIDs.py takes the sequence IDs selected from the blast output 
 and finds them in the original query fasta file.  
@@ -524,14 +519,14 @@ What each argument is:
 What each file is:
 	create_fastas_given_seqIDs.py	the python script you're sourcing 
 	ids.above.98					the file of seqIDs at or above your cutoff from step 4
-	ids.below.98					the file of all seqIDs below your cutoff from step 6
+	ids.below.98.all				the file of all seqIDs below your cutoff from step 6
 	otus.fasta						the original fasta file of your otu sequences
 	otus.above.98.fasta				the output file with fasta sequences at or above your cutoff
 	otus.below.98.fasta				the output file with fasta sequences below your cutoff
 	
 __________________________________________________________________________________________
 
-8. assign taxonomy (mothur)
+9. assign taxonomy (mothur)
 
 The classify.seqs() command in mothur classifies sequences using a specified algorithm 
 and a provided taxonomy database.  I use the default algorithm (wang with kmer size 8), 
@@ -551,8 +546,8 @@ What the first and last commands do:
 	quit()				exits the mothur program and returns you back to bash in the terminal.
 
 What the filenames are:
-	otus.above.98.fasta		this is the fasta file containing only seqIDs >= your cutoff, from step 6
-	otus.below.98.fasta		this is the fasta file containing only seqIDs < your cutoff, from step 6
+	otus.above.98.fasta		this is the fasta file containing only seqIDs >= your cutoff, from step 8
+	otus.below.98.fasta		this is the fasta file containing only seqIDs < your cutoff, from step 8
 	custom.fasta			this is the fasta file for your small custom taxonomy database (ie freshwater) 
 	general.fasta			this is the fasta file for your large general taxonomy database (ie green genes) 
 	custom.taxonomy			this is the .taxonomy file for your small custom taxonomy database (ie freshwater)
@@ -583,12 +578,12 @@ NOTE: these bootstrap percent confidence values are NOT the confidence that the 
 assignment is *correct*, just that it is *repeatable* in that database.  This is another 
 paremeter that we could explore changing more in the future.  It likely should be different
 in the different databases also because of the different database sizes.  I left cutoff out
-in this command so that you can explore the different results of it later, in steps 12-13.
+in this command so that you can explore the different results of it later, in steps 13-14.
 
 
 __________________________________________________________________________________________
 
-9. combine taxonomy files (terminal)
+10. combine taxonomy files (terminal)
 
 Concatenate the two taxonomy files to create one complete one.  You can very simply just 
 combine them because there are no duplicate sequences between them.  The cat command in bash
@@ -610,10 +605,10 @@ What the filenames are:
 
 __________________________________________________________________________________________
 
-Steps 10-13 are an optional check.
+Steps 11-14 are an optional check.
 __________________________________________________________________________________________
 
-10. assign taxonomy with general database only (mothur, bash)
+11. assign taxonomy with general database only (mothur, bash)
 
 Get a large, general database classification of your otus.fasta file to compare too.  
 Green Genes, our general database choice, is a huge database (1,262,986 sequences), so the 
@@ -631,7 +626,7 @@ mothur "#classify.seqs(fasta=otus.fasta, template=general.fasta, taxonomy=genera
 cat otus.general.wang.taxonomy > otus.general.taxonomy
 
 What the commands do:
-	See step 8 for a detailed explanation of these two commands and their arguments.
+	See step 9 for a detailed explanation of these two commands and their arguments.
 
 What the filenames are:
 	otus.fasta					the original fasta file of your OTU sequences
@@ -644,10 +639,10 @@ What the filenames are:
 
 __________________________________________________________________________________________
 
-11. assign taxonomy to custom database with general database (mothur, bash)
+11.5 assign taxonomy to custom database with general database (mothur, bash)
 
 This allows you to compare your two databases to get an idea of the baseline level of 
-disagreement you can expect from their taxonomy classifications.  Also, in step 12 you
+disagreement you can expect from their taxonomy classifications.  Also, in step 13 you
 will generate a list of these disagreements that you can use to update your custom
 database classifications to better match your general database, if desired.  When you 
 choose an appropriate pident cutoff the goal is to avoid forcing OTUs into the custom
@@ -662,7 +657,7 @@ cat custom.general.wang.taxonomy custom.general.taxonomy
 
 
 What the commands do:
-	See step 8 for a detailed explanation of these two commands and their arguments.
+	See step 9 for a detailed explanation of these two commands and their arguments.
 
 What the filenames are:
 	custom.fasta					the fasta file of the small, custom database
@@ -674,14 +669,14 @@ What the filenames are:
 	
 __________________________________________________________________________________________
 
-11. reformat taxonomy files (bash)
+12. reformat taxonomy files (bash)
 
-The R script in step 12 requires semicolon delimited taxonomy files.  The mothur output
+The R script in step 13 requires semicolon delimited taxonomy files.  The mothur output
 .taxonomy files are delimited with both tabs and semicolons.
 
 Reformat both files you will compare:
-	the otus.taxonomy file created in step 9
-	the otus.general.taxonomy file created in step 10
+	the otus.taxonomy file created in step 10
+	the otus.general.taxonomy file created in step 11
 
 Find: tab
 Replace: semicolon
@@ -712,7 +707,7 @@ Syntax of commands and what each argument does:
 
 __________________________________________________________________________________________
 
-12. compare taxonomy files (bash, R)
+13. compare taxonomy files (bash, R)
 
 The R script find_classification_disagreements.R  creates a folder containing a file for 
 each upper taxonomic level (kingdom, phylum, class, order, lineage) that lists all of the 
@@ -732,7 +727,7 @@ Additionally, this script generates a final version of your taxonomy file with t
 bootstrap cutoff implemented.  The version made in step 9 contains all the taxonomy assignments,
 even ones with very low bootstrap p-values.  This generates a .taxonomy file with the cutoff
 applied, so that everything under that cutoff is named "unclassified."  Note that you can 
-apply this cutoff in step 8 using the "cutoff = #" flag with the mothur command classify.seqs().
+apply this cutoff in step 9 using the "cutoff = #" flag with the mothur command classify.seqs().
 I didn't do it there though to make these analysis steps more flexible. The format of this file
 is semicolon delimited, which is slightly different than the mothur output files that are tab 
 semicolon deliminited between taxonomy levels but tab delimited between the seqID column and
@@ -753,9 +748,9 @@ What the arguments are the first time you source the script:
 1.	Rscript									this opens R to accept arguments from the command line
 2.	find_classification_disagreements.R		this is the R script you're sourcing
 3.	otus.98.taxonomy						this is the path to your otu taxonomy file 
-											created using both databases in step 9
+											created using both databases in step 10
 4.	otus.general.taxonomy					this is the path to your otu taxonomy file
-											created using only the general database in step 10
+											created using only the general database in step 11
 5.	ids.above.98							this is the path to the file created in step 4 that
 											contains all of the sequence IDs above or equal to 
 											your pident cutoff
@@ -774,7 +769,7 @@ What the arguments are the second time you source the script:
 1.	Rscript									this opens R to accept arguments from the command line
 2.	find_classification_disagreements.R		this is the R script you're sourcing
 3.	custom.custom.taxonomy					this is the path to your custom taxonomy database 
-											after re-formatting it in step 11.
+											after re-formatting it in step 12.
 4.	custom.general.taxonomy					this is the path to your custom taxonomy database
 											classified using the general database in step 11.
 5.	NA										NA is typed as a placeholder here
@@ -801,11 +796,11 @@ What the generated files in your conflicts folders are:
 
 __________________________________________________________________________________________
 
-13. choose appropriate pident cutoff (R)
+14. choose appropriate pident cutoff (R)
 
 This step generates some plots that you can use to double check that your chosen cutoff is 
-appropriate.  The plots are saved into the "plots" folder that you created in step 5.  In
-order to examine the cutoff sensitivity, you may want to run steps 4-9 & 11-13 multiple times
+appropriate.  The plots are saved into the "plots" folder that you created in step 6.  In
+order to examine the cutoff sensitivity, you may want to run steps 4-10 & 12-13 multiple times
 with different pident cutoffs.  Note that the slowest step, classify.seqs() in mothur, will
 be much faster because the mothur database files are not re-made.
 
@@ -816,7 +811,7 @@ What the arguments are:
 2.		plot_classification_disagreements.R		name of the script you are calling
 3.		otus.abund								OTU relative abundance table
 4.		plots									path to folder you are saving the plots into.
-												note: this folder must already exist. you made it in step 5.
+												note: this folder must already exist. you made it in step 6.
 5.		conflicts_database						path to folder containing taxonomy disagreements between
 												the custom and the general database.
 												You made this folder in step 12.
@@ -824,7 +819,7 @@ What the arguments are:
 7.		regular									also placeholder. Note: these must say "regular" though.
 6.		conflicts_94							path to folder containing taxonomy disagreements between
 												this cutom+general workflow and the general database alone.
-												You made this folder in step 12.
+												You made this folder in step 13.
 7.		ids.above.94							path to the file that lists all the seqIDs meeting your
 												pident cutoff that were therefore classified with your
 												custom databse. You made this file in step 4.
@@ -842,15 +837,15 @@ What the generated plots are:
 
 __________________________________________________________________________________________
 
-14. generate final taxonomy file (R)
+15. generate final taxonomy file (R)
 
-Based on your results from step 13, choose which pident cutoff to use.  Use the same script 
-from step 12, except this time specify "final."  This final taxonomy file is different from 
+Based on your results from step 14, choose which pident cutoff to use.  Use the same script 
+from step 13, except this time specify "final."  This final taxonomy file is different from 
 files created in step 9 because it applies your clustering bootstrap pvalue cutoff, calling
 everything below that cutoff "unclassified."  
 
 Recall that choosing that cutoff was left out of the mothur command to allow flexibility in
-analyzing results.  The "final" argument to this script is left out in step 12 because it takes
+analyzing results.  The "final" argument to this script is left out in step 13 because it takes
 longer when it is included.  This is because in finding the classification disagreements, the
 script only compares classifications assigned by the custom database, which is a small subset 
 of all of the classifications.
@@ -861,9 +856,9 @@ What the arguments are this (3rd) time you source the script:
 1.	Rscript									this opens R to accept arguments from the command line
 2.	find_classification_disagreements.R		this is the R script you're sourcing
 3.	otus.98.taxonomy						this is the path to your otu taxonomy file 
-											created using both databases in step 9
+											created using both databases in step 10
 4.	otus.general.taxonomy					this is the path to your otu taxonomy file
-											created using only the general database in step 10
+											created using only the general database in step 11
 5.	ids.above.98							this is the path to the file created in step 4 that
 											contains all of the sequence IDs above or equal to 
 											your pident cutoff
@@ -885,15 +880,15 @@ What the arguments are this (3rd) time you source the script:
 
 __________________________________________________________________________________________
 
-15. OPTIONAL: plot benefits of using this workflow (R)
+15.5 OPTIONAL: plot benefits of using this workflow (R)
 
-15.a Plot improvement over using general database alone
+15.5.a. Plot improvement over using general database alone
 
 In this step two plots are generated that show you the benefit of using the custom workflow.
 The plots show the number of known taxonomic assignments by either % of total OTUs or % of 
 total reads.  Basically, the script sums up everything that is not called "unclassified"
 in the final workflow taxonomy file and the general database taxonomy file with the bootstrap
-p-value cutoffs applied.  These files are both generated in step 14.
+p-value cutoffs applied.  These files are both generated in step 15.
 
 Full Command (Type into terminal):
 
@@ -901,23 +896,23 @@ Rscript plot_classification_improvement.R final.taxonomy.pvalues final.general.p
 
 What the arguments are:
 	final.taxonomy.pvalues			a file of p-values corresponding to the final taxonomy file you
-									generated in step 14.  This file, with this name, was automatically
-									generated in step 14 so it is already in your working directory.
+									generated in step 15.  This file, with this name, was automatically
+									generated in step 15 so it is already in your working directory.
 	final.general.pvalues 			a file of p-values corresponding to the general-classified taxonomy
 									after the classification p-value cutoff has been applied. This file,
-									with this name, was automatically generated in step 14 so it is already
+									with this name, was automatically generated in step 15 so it is already
 									in your working directory.
 	total.reads.per.seqID			a file that lists each seqID and the total number of reads for that
 									seqID.  This file, with this name, was automatically generated in
 									step 13, using your otus.abund table, so it is already in your 
 									working directory.
 	plots							the name of the folder that plots are saved into.  you created this
-									folder in step 5.
+									folder in step 6.
 
-15.b Plot folly of using custom database alone
+15.5.b. Plot folly of using custom database alone
 
 In this step the classifications you get using the custom database alone are compared to the final workflow
-taxonomy file generated in step 14.  The plots created show the "forcing" that would occur from using only
+taxonomy file generated in step 15.  The plots created show the "forcing" that would occur from using only
 the small database.  Forcing occurs because the RDP classifier classifies sequences stochastically, putting
 them with the most similar sequence *in your database*.  If there are no similar sequences and the database is 
 large, then the sequence will be put somewhere different each time, end up with a low p-value, and be called
@@ -970,8 +965,8 @@ otus.[0-9][0-9].taxonomy otus.[0-9][0-9][0-9].taxonomy otus.general.taxonomy otu
 				the classifications at different pident cutoffs and from general and custom alone and the database comparison
 				note: these files don't have p-value cutoffs applied (i.e. nothing's called unclassified). 
 				If you want to save files like these for additional analysis, 
-					re-run step 14 to get additional "final" versions.
-					re-run step 10 with an additional "cutoff=" flag.
+					re-run step 15 to get additional "final" versions.
+					re-run step 11 with an additional "cutoff=" flag.
 *pvalues total*	These are files generated to use in the plot improvement script
 
 

--- a/Clean workflow
+++ b/Clean workflow
@@ -69,7 +69,6 @@ NOTE: steps 1-14 can be run in a block using the bash script LazyRun.sh.  to sou
 	mkdir conflicts_98
 	Rscript find_classification_disagreements.R otus.98.taxonomy otus.general.taxonomy ids.above.98 conflicts_98 98 85 70
 	
-
 14. choose appropriate pident cutoff (R)
 	Rscript plot_classification_disagreements.R otus.abund plots regular NA conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98
 

--- a/arb-scripts/Database_Improvement_Workflow.txt
+++ b/arb-scripts/Database_Improvement_Workflow.txt
@@ -1,0 +1,172 @@
+RRR 3-11-16
+
+These are steps that you can add to the taxonomy assignment workflow in order to check 
+for mistakes in your custom database.  Some of them are scripts that you run as part of
+the taxonomy classification workflow, and others are scripts that you use before the workflow
+directly on the files that arb exports.
+
+*** the file names are not consistent yet***
+
+===========================================================================================
+I. Pre-workflow scripts (in this folder, copy into a separate working directory to run)
+===========================================================================================
+
+1. replace U and . with T and - (perl)
+	cat myseqs.fa | prepareARBaligns4tree.pl > mycleanseqs.fa
+
+2. make file semicolon delimited (bash)
+	sed 's/[[:blank:]]/\;/' <otus.98.taxonomy >otus.98.taxonomy.reformatted
+
+3. replace blanks with "unclassified" (R)
+	replace_blanks_with_unclassified.R (no terminal call yet)
+
+4. return to first column being tab delimited for mothur (bash)
+	./replace_first_semicolon_with_tab.sh
+
+===========================================================================================
+II. In-workflow scripts (these scripts are part of the workflow, so they are in the tax-scripts
+						folder and they require files generated in the workflow. Call these 
+						scripts with these different flags from within your workflow working 
+						directory and at the correct point in the workflow processing.)
+===========================================================================================
+
+1. compare custom and general database names (R)
+
+2. Find typos that result in an two lower-taxa-level orgs of the same name having a different upper name
+	find_typos.R
+
+3. Find high-read seqIDs that are missing in the FW database- prioritize adding these sequences
+	Find_Abund_SeqIDs_to_Add.R
+
+
+___________________________________________________________________________________________
+
+===========================================================================================
+I. Pre-workflow scripts:
+===========================================================================================
+
+___________________________________________________________________________________________
+
+1. replace U and . with T and - (perl)
+
+This script prepareARBaligns4tree.pl is something Trina wrote and has been using for a long time. 
+ARB thinks these are RNA sequences so its output uses U instead of T.  Also it has periods 
+instead of dashes for gaps. This script just does find and replace:
+find: U
+replace: T
+find: .
+replace: -
+
+full command (Type in Terminal)
+
+cat myseqs.fa | prepareARBaligns4tree.pl > mycleanseqs.fa
+
+___________________________________________________________________________________________
+
+2. make file semicolon delimited (bash)
+
+This is necessary to read the file into R in the next step.  R gets very unhappy if there
+are multiple column delimiters.  Or rather, I get very unhappy trying to import into R if
+there are multiple column delimiters.
+
+full command (type into terminal):
+
+sed 's/[[:blank:]]/\;/' <otus.98.taxonomy >otus.98.taxonomy.reformatted
+
+
+___________________________________________________________________________________________
+
+3. replace blanks with "unclassified" (R)
+
+The script replace_blanks_with_unclassified.R finds all the blank entries in the database
+and instead of leaving it blank calls it "unclassified". These blanks occur when the classification
+at a lower level is unknown.  You need to have some word there because otherwise the RDP
+classifier doesn't work correctly.  It takes a computational shortcut when calculating bootstrap
+p-values where for higher taxonomy levels it simply sums the lower levels.  If the lower level is 
+totally blank there's nothing to sum up, so the highest level ends up being less than 100%.
+
+I haven't made this script work from the terminal yet, you have to open it and type in the path.
+
+___________________________________________________________________________________________
+
+4. return to first column being tab delimited for mothur (bash)
+
+mothur requires that mix of tab and semicolon delimited-ness, so now have to change it back.
+sed doesn't recognize \t because it's stupid, so have to source a bash script.
+
+full command (type in terminal)
+
+./replace_first_semicolon_with_tab.sh
+
+*** this needs to also add back the semicolon at the end of the line too.  I think I just did 
+that in text wrangler before.  pretty sure the # fuck line in the script is a placeholder for that...
+***
+
+___________________________________________________________________________________________
+
+===========================================================================================
+I. Mid-workflow scripts:
+===========================================================================================
+___________________________________________________________________________________________
+
+1. Compare general database classification of your custom database representative OTUs to
+	identify drift in database curation as they are updated separately.
+
+10.5 compare custom and general databases (mothur, bash)
+	mothur "#classify.seqs(fasta=custom.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
+	cat custom.general.wang.taxonomy > custom.general.taxonomy
+	sed 's/[[:blank:]]/\;/' <custom.general.taxonomy >custom.general.taxonomy.reformatted
+	mv custom.general.taxonomy.reformatted custom.general.taxonomy
+	sed 's/[[:blank:]]/\;/' <custom.taxonomy >custom.custom.taxonomy
+	mkdir conflicts_database
+	Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA NA 70 database 
+	note, can also add database conflicts to the plot from within RStudio, but took the input out of the plot_classification_disagreements.R terminal call.
+
+
+*****description*****
+
+
+___________________________________________________________________________________________
+
+1. workflow step 10.5, 11.5, 12.5, and manual step 13.5
+
+
+
+***description***
+
+
+
+
+___________________________________________________________________________________________
+
+2. This uses the R script find_typos.R, which is not ready for terminal call yet.
+
+
+
+
+***description***
+
+
+
+___________________________________________________________________________________________
+
+3. Find high-read seqIDs that are missing in the FW database- prioritize adding these sequences
+
+not sourceable from command line yet
+
+***description***
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/arb-scripts/Find_Abund_SeqIDs_to_Add.R
+++ b/arb-scripts/Find_Abund_SeqIDs_to_Add.R
@@ -1,0 +1,216 @@
+# RRR 3-1-16
+# This is a script to find high read seqIDs that are missing from FW database
+
+
+#####
+# Define File Paths and Input Variables
+#####
+
+# input
+seqID.reads.file.path <- "~/Desktop/TaxonomyTrainingSets/BLASTing/take13/total.reads.per.seqID.csv"
+ave.perc.abund.cutoff <- .1
+ids.classified.by.fw.file.path <- "~/Desktop/TaxonomyTrainingSets/BLASTing/take13/ids.above.99"
+taxonomy.table.file.path <- "~/Desktop/TaxonomyTrainingSets/BLASTing/take13/otus.99.taxonomy"
+blast.pidents.file.path <- "~/Desktop/TaxonomyTrainingSets/BLASTing/take13/otus.custom.blast.table.modified"
+
+# output
+priority.taxa.file.path <- "~/Dropbox/Trina/3-3-16 priority seqIDs to add to ARB/mendota_priority_seqID_taxonomies.csv"
+priority.seqIDs.file.path <- "~/Desktop/TaxonomyTrainingSets/BLASTing/take13/mendota_priority_seqIDs_for_step7"
+
+#####
+# Define functions for import/export
+#####
+
+import.seqID.reads <- function(FilePath){
+  seqID.reads.file.path <- FilePath
+  
+  seqID.reads <- read.csv(file = seqID.reads.file.path, stringsAsFactors = FALSE)
+  seqID.reads[ ,1] <- as.character(seqID.reads[ ,1])
+  seqID.reads[ ,2] <- as.numeric(seqID.reads[ ,2])
+  
+  return(seqID.reads)
+}
+
+import.fw.ids <- function(FilePath){
+  ids.above.path <- FilePath
+  
+  # scan is only able to import numbers, throws error if values are character
+  fw.ids <- read.table(file = ids.above.path, stringsAsFactors = FALSE)
+  fw.ids <- fw.ids[ ,1]
+  fw.ids <- as.character(fw.ids)
+  
+  return(fw.ids)
+}
+
+import.taxonomy.assignments <- function(FilePath){
+  taxonomy.table.file.path <- FilePath
+  tax.table <- read.table(file = taxonomy.table.file.path, header = FALSE, sep = ";", stringsAsFactors = FALSE)
+  tax.table <- tax.table[ ,-9]
+  tax.table[ ,1] <- as.character(tax.table[ ,1])
+  return(tax.table)
+}
+
+import.blast.pidents <- function(FilePath){
+  blast.pidents.file.path <- FilePath
+  
+  blast.stats <- read.table(file = blast.pidents.file.path, header = FALSE, sep = "\t", stringsAsFactors = FALSE)
+  seqIDs.pidents <- blast.stats[ ,c(1,6)]
+  colnames(seqIDs.pidents) <- c("seqID","full.pident")
+  
+  return(seqIDs.pidents)
+}
+
+export.priority.taxa.for.Trina <- function(PriorityTaxaTable, FilePath){
+  priority.taxa.file.path <- FilePath
+  priority.taxa <- PriorityTaxaTable
+  
+  write.csv(x = priority.taxa, file = priority.taxa.file.path, row.names = FALSE, quote = FALSE)
+  cat("\nWrote file ", priority.taxa.file.path, 
+      "\nThe format is comma delimited columns: seqID, average % abundance, corrected blast pident, taxonomy assignments",
+      "\nNote that average % abundance is in percents- 0.1 means 0.1 % not 10 %",
+      "\nNote that taxonomy names include all assignments- only trust p-values that are at least 70 %",
+      "\nNote that pident values of NA are for sequences with e-values too low for plast to return a hit")
+}
+
+export.priority.seqIDs.to.grab.fastas <- function(PrioritySeqIDsTable, FilePath){
+  priority.seqIDs.file.path <- FilePath
+  priority.seqIDs <- PrioritySeqIDsTable
+  
+  write.table(x = priority.seqIDs[ ,1], file = priority.seqIDs.file.path, row.names = FALSE, quote = FALSE, col.names = FALSE)
+  cat("\nWrote file ", priority.seqIDs.file.path, 
+      "\nThis is a list of the seqIDs with high average (over all samples) relative abundance that are not similar to anything currently in the FW database.",
+      "\nThe format is accepted by step 7 of the taxonomy assignment workflow, which creates a fasta file for a list of seqIDs\n")
+}
+
+#####
+# Define functions for analysis
+#####
+
+find.abund.seqIDs <- function(TotReadsTable, PercAbundCutoff){
+  seqID.reads <- TotReadsTable
+  cutoff <- PercAbundCutoff
+  
+  # Change to average percent abundance (averaged over all samples)
+  tot.reads <- sum(seqID.reads$reads)
+  seqID.reads[ ,2] <- seqID.reads[ ,2] / tot.reads * 100
+  colnames(seqID.reads)[2] <- "AvePercAbund"
+  
+  # Remove IDs below cutoff, removing here makes tables smaller so next step faster
+  index <- order(seqID.reads[ ,2], decreasing = TRUE)
+  seqID.reads <- seqID.reads[index, ]
+  
+  index <- which(seqID.reads[ ,2] >= cutoff)
+  seqID.reads <- seqID.reads[index, ]
+  
+  return(seqID.reads)
+}
+
+remove.seqIDs.in.FW.already <- function(TotReadsTable, FWseqIDs){
+  abund.seqIDs <- TotReadsTable
+  fw.ids <- FWseqIDs
+  
+  # Using counters f and a: f = each fw ID, a = each abund read
+  index <- NULL
+  for (f in 1:length(fw.ids)){
+    for (a in 1:nrow(abund.seqIDs)){
+      if (fw.ids[f] == abund.seqIDs[a,1]){
+        index <- c(index,a)
+      }
+    }
+  }
+  abund.seqIDs <- abund.seqIDs[-index, ]
+  return(abund.seqIDs)
+}
+
+find.pidents.of.priority.seqIDs <- function(SeqIDsTable, BlastTable){
+  priority.seqIDs <- SeqIDsTable
+  seqIDs.pidents <- BlastTable
+  
+  index <- NULL
+  for(s in 1:nrow(priority.seqIDs)){
+    temp.index <- which(seqIDs.pidents[ ,1] == priority.seqIDs[s,1])
+    index <- c(index, temp.index)
+  }
+  priority.pidents <- seqIDs.pidents[index, ]
+  
+  return(priority.pidents)
+}
+
+find.tax.assignments.of.priority.seqIDs <- function(SeqIDsTable, TaxonomyTable){
+  priority.seqIDs <- SeqIDsTable
+  tax.table <- TaxonomyTable
+  
+  index <- NULL
+  for (s in 1:nrow(priority.seqIDs)){
+    temp.index <- which(tax.table[ ,1] == priority.seqIDs[s,1])
+    index <- c(index, temp.index)
+  }
+  tax.table <- tax.table[index, ]
+  colnames(tax.table) <- c("seqID","kingdom","phylum","class","order","family","genus","species")
+  return(tax.table)
+}
+
+combine.taxonomy.abundance.pidents <- function(TaxonomyTable, AbundanceTable, BlastTable){
+  priority.seqIDs <- AbundanceTable
+  priority.taxa <- TaxonomyTable
+  priority.pidents <- BlastTable
+  
+  # the order of seqIDs must match to combine tables
+  index.1 <- order(priority.seqIDs[ ,1])
+  index.2 <- order(priority.taxa[ ,1])
+  priority.seqIDs <- priority.seqIDs[index.1, ]
+  priority.taxa <- priority.taxa[index.2, ]
+  
+  # the blast results do not include all seqIDs, add NA for missing pidents
+  all.priority.pidents <- data.frame(seqIDs = "placeholder", pidents = 0, stringsAsFactors = FALSE)
+  for (s in 1:nrow(priority.seqIDs)){
+    index <- which(priority.seqIDs[s,1] == priority.pidents[ ,1])
+    if(length(index) > 0){
+      all.priority.pidents[s, ] <- priority.pidents[index, ]
+    }else{
+      all.priority.pidents[s, ] <- c(priority.seqIDs[s,1], NA)
+    }
+  }
+  
+  cat("\ndo taxonomy and read seqIDs match: ", all.equal(priority.seqIDs[ ,1], priority.taxa[ ,1]))
+  cat("\ndo taxonomy and pident seqIDs match: ", all.equal(all.priority.pidents[ ,1], priority.taxa[ ,1]))
+  
+  # add tables together so Trina can see taxonomy, abundance, and pident all together.
+  priority.taxa <- cbind(priority.seqIDs, all.priority.pidents[ ,-1, drop = FALSE], priority.taxa[ ,-1])
+  index <- order(priority.taxa[ ,2], decreasing = TRUE)
+  priority.taxa <- priority.taxa[index, ]
+  
+  return(priority.taxa)
+}
+
+#####
+# Use functions
+#####
+
+# import data
+seqID.reads <- import.seqID.reads(FilePath = seqID.reads.file.path)
+
+fw.ids <- import.fw.ids(FilePath = ids.classified.by.fw.file.path)
+
+tax.table <- import.taxonomy.assignments(FilePath = taxonomy.table.file.path)
+
+seqIDs.pidents <- import.blast.pidents(FilePath = blast.pidents.file.path)
+
+
+# process data
+abund.seqIDs <- find.abund.seqIDs(TotReadsTable = seqID.reads, PercAbundCutoff = ave.perc.abund.cutoff)
+
+priority.seqIDs <- remove.seqIDs.in.FW.already(TotReadsTable = abund.seqIDs, FWseqIDs = fw.ids)
+
+priority.pidents <- find.pidents.of.priority.seqIDs(SeqIDsTable = priority.seqIDs, BlastTable = seqIDs.pidents)
+
+priority.taxa <- find.tax.assignments.of.priority.seqIDs(SeqIDsTable = priority.seqIDs, TaxonomyTable = tax.table)
+
+priority.taxa <- combine.taxonomy.abundance.pidents(TaxonomyTable = priority.taxa, AbundanceTable = priority.seqIDs, BlastTable = priority.pidents)
+
+
+#export data
+export.priority.taxa.for.Trina(PriorityTaxaTable = priority.taxa, FilePath = priority.taxa.file.path)
+
+export.priority.seqIDs.to.grab.fastas(PrioritySeqIDsTable = priority.seqIDs, FilePath = priority.seqIDs.file.path)
+

--- a/arb-scripts/README.md
+++ b/arb-scripts/README.md
@@ -1,0 +1,11 @@
+These are scripts for reformatting the ARB output of the Freshwater Training Set
+
+Robin's in the process of pulling them together into a repeatable workflow.
+That's gonna be in this repo soon.
+
+The .pl script is the one Trina uses already.
+The ones Robin's adding are to address bugs she's encountered while working on 16STaxAss.
+
+When Robin is not writing code, she enjoys referring to herself in the 3rd person.
+
+RRR 2-8-16

--- a/arb-scripts/find_typos.R
+++ b/arb-scripts/find_typos.R
@@ -1,0 +1,187 @@
+# RRR 2-8-16
+# finding typos in FW taxonomy by looking for duplicate names with different phylogenies above them
+
+#####
+# Define File Paths
+#####
+
+comma.delim.trainingset <- "../../take10/custom.custom.taxonomy"
+results.folder <- "~/Desktop/tax_typos"
+
+
+#####
+# Define Functions
+#####
+
+# import FW training set (semicolon delimited)
+import.taxonomy <- function(FilePath){
+  numcol <- max(count.fields(FilePath, sep=";"))
+  taxonomy <- read.table(FilePath, sep=";", fill=T, stringsAsFactors = F, col.names=1:numcol)
+  taxonomy<- taxonomy[1:8]
+  colnames(taxonomy) <- c("seqID","kingdom","phylum","class","order","lineage","clade","tribe")
+  taxonomy <- as.matrix(taxonomy)
+  return(taxonomy)
+}
+
+# fix the blank spots that cause p-value errors in RDP-classifier
+make.empty.names.unclassified <- function(TaxonomyTable){
+  taxonomy <- TaxonomyTable
+  index <- which(taxonomy == "")
+  taxonomy[index] <- "unclassified"
+  return(taxonomy)
+}
+
+# Make a unique taxonomy table (so that duplicate names are indexed)
+make.names.unique <- function(TaxonomyTable){
+  taxonomy <- TaxonomyTable
+  index <- order(taxonomy[ ,2], taxonomy[ ,3], taxonomy[ ,4], taxonomy[ ,5], taxonomy[ ,6], taxonomy[ ,7], taxonomy[ ,8])
+  taxonomy.ord <- taxonomy[index, ]
+  
+  for (t in 2:8){
+    unique.taxa <- unique(taxonomy.ord[ ,2:t, drop = FALSE])          
+    unique.names <- make.unique(unique.taxa[,(t-1)])       
+    for (u in 1:nrow(unique.taxa)){                     
+      for (r in 1:nrow(taxonomy.ord)){
+        if (all(taxonomy.ord[r,2:t] == unique.taxa[u,1:(t-1)])){
+          taxonomy.ord[r,t] <- unique.names[u]
+        }
+      }
+    }
+  }
+  return(taxonomy.ord)
+}
+
+# Create a list with unique names at each taxonomic level 
+list.names.by.tax.level <- function(TaxonomyTable){
+  taxonomy.ord <- TaxonomyTable
+  grouped.taxa <- list("kingdom"=NULL, "phylum"=NULL, "class"=NULL, "order"=NULL, "lineage"=NULL, "clade"=NULL, "tribe"=NULL)
+  
+  for (t in 1:7){
+    grouped.taxa[[t]] <- unique(taxonomy.ord[ ,(2:(t+1)), drop = FALSE])
+    colnames(grouped.taxa[[t]]) <- colnames(taxonomy.ord)[(2:(t+1))]
+    rownames(grouped.taxa[[t]])<- NULL
+  }
+  return(grouped.taxa)
+}
+
+# pull out all of the names with periods in them from indexing, then look at only ones that weren't unclassified
+find.typos.from.repeat.names <- function(TaxonomyList){
+  grouped.taxa <- TaxonomyList
+  typos <- list("kingdom"=NULL, "phylum"=NULL, "class"=NULL, "order"=NULL, "lineage"=NULL, "clade"=NULL, "tribe"=NULL)
+  
+  for (t in 1:7){
+    typos[[t]] <- grep(x = grouped.taxa[[t]][ ,t], pattern = ".*\\..*", value = TRUE)
+    index.unclassifieds <- grep(x = typos[[t]], pattern =  "unclassified.*", value = FALSE )
+    typos[[t]] <- typos[[t]][-index.unclassifieds]
+  }
+  return(typos)
+}
+
+# find the corresponding seqIDs to check in ARB
+find.taxonomy.of.typos <- function(TyposList){
+  typos <- TyposList
+  typo.taxonomies <- list("kingdom"=NULL, "phylum"=NULL, "class"=NULL, "order"=NULL, "lineage"=NULL, "clade"=NULL, "tribe"=NULL)
+  
+  for (t in 1:7){
+    typo.names <- sub(x = typos[[t]], pattern = "\\..*", replacement = "")
+    for (n in 1:length(typo.names)){
+      seqID.indeces <- which(taxonomy[ ,(t+1)] == typo.names[n])
+      typo.taxonomies[[t]] <- rbind(typo.taxonomies[[t]], taxonomy[seqID.indeces, ])
+    }
+  }
+  return(typo.taxonomies)
+}
+
+# write these names to excel sheets for Trina to fix in ARB :) thanks trina!
+export.typos.into.excel <- function(TyposList, FilePath){
+  typo.taxonomies <- TyposList
+  results.folder <- FilePath
+  for (t in 1:7){
+    write.csv(x = typo.taxonomies[[t]], file = paste(results.folder, "/", t, "_dups_at_", names(typos)[t], "_level.csv", sep = ""), row.names = FALSE)
+  }
+  cat("Files written in folder ", results.folder)
+}
+
+# Find the specific seqID names of the typos to make Trina's life easier
+pull.out.incorrect.seqIDs <- function(TaxonomyList){
+  typo.taxonomies <- TaxonomyList
+  
+  typo.seqIDs <- NULL
+  seqID.counter <- 1
+  # loop counters are t, d, n, s, o in that order- don't re-use these variables! :)
+  for (t in 1:7){
+    # ignore the taxa levels that have no duplicate names
+    if (nrow(typo.taxonomies[[t]]) > 0){
+      
+      # look at the taxa for each duplicate name separately
+      dup.names <- unique(typo.taxonomies[[t]][ ,(t + 1)])
+      for (d in 1:length(dup.names)){
+        dup.indeces <- which(typo.taxonomies[[t]][ ,(t + 1)] == dup.names[d])
+        dup.taxonomies <- typo.taxonomies[[t]][dup.indeces, ]
+        typo.names <- unique(dup.taxonomies[ ,t])
+        
+        # ignore the duplicates that arrise from typos more than one taxa level up
+        if (length(typo.names) > 1){
+          
+          # assume the name that occurs most is correct
+          num.names <- 0
+          for (n in 1:length(typo.names)){
+            num.names[n] <- length(which(dup.taxonomies[ ,t] == typo.names[n]))
+          }
+          name.index <- which(num.names == max(num.names))
+          the.typo.is <- typo.names[-(name.index)]
+          the.typo.isnt <- typo.names[name.index]
+          
+          # get the seqIDs for all of the names the typo is (i)
+          seqID.index <- NULL
+          for (i in 1:length(the.typo.is)){
+            seqID.index <- which(dup.taxonomies[ ,t] == the.typo.is[i])
+            the.seqID.is <- dup.taxonomies[seqID.index,1]
+            
+            # save the seqIDs of interest, allowing for there to be multiple seqIDs (s) for each different name the typo is (i) 
+            for (s in 1:length(the.seqID.is)){
+              typo.seqIDs[seqID.counter] <- paste("the seqID ", the.seqID.is[s], " has ", names(typo.taxonomies)[t-1], " ", the.typo.is[i],  
+                                                  " while most ", dup.names[d], " are ", the.typo.isnt, sep = "")
+              cat(typo.seqIDs[seqID.counter],"\n")
+              seqID.counter <- seqID.counter + 1
+            }
+          }
+        }
+      }
+    }
+  }
+  return(typo.seqIDs)
+}
+
+export.seqIDs.to.fix <- function(FilePath, SeqIDsWithTypos){
+  results.folder <- FilePath
+  typo.seqIDs <- SeqIDsWithTypos
+  
+  write.csv(x = typo.seqIDs, file = paste(results.folder, "/SeqIDs_to_Fix.csv", sep = ""), row.names = FALSE)
+}
+
+#####
+# Use Functions
+#####
+
+taxonomy <- import.taxonomy(FilePath = comma.delim.trainingset)
+
+taxonomy <- make.empty.names.unclassified(TaxonomyTable = taxonomy)
+
+taxonomy.ord <- make.names.unique(TaxonomyTable = taxonomy)
+
+grouped.taxa <- list.names.by.tax.level(TaxonomyTable = taxonomy.ord)
+
+typos <- find.typos.from.repeat.names(TaxonomyList = grouped.taxa)
+
+typo.taxonomies <- find.taxonomy.of.typos(TyposList = typos)
+
+export.typos.into.excel(TyposList = typo.taxonomies, FilePath = results.folder)
+
+typo.seqIDs <- pull.out.incorrect.seqIDs(TaxonomyList = typo.taxonomies)
+
+export.seqIDs.to.fix(FilePath = results.folder, SeqIDsWithTypos = typo.seqIDs)
+
+
+
+

--- a/arb-scripts/prepareARBaligns4tree.pl
+++ b/arb-scripts/prepareARBaligns4tree.pl
@@ -1,0 +1,50 @@
+#!/opt/local/bin/perl
+
+#
+
+
+use strict;
+use Benchmark qw(:all);
+use Data::Dumper;
+
+
+my $USAGE=<<USAGE;
+
+ * prepareARBaligns4tree.pl *
+ 
+   Replaces the U's in a sequence with T's and "."s with "-"s, without touching the defline.
+   Useful for ARB alignments that need to go into tree-building programs or to use in 16S 
+   taxonomy trainingsets. 
+ 
+   usage:
+
+   cat myseqs.fa | prepareARBaligns4tree.pl > mycleanseqs.fa
+
+    - for getting this help -
+
+    replaceUs.pl -h
+    replaceUs.pl --help
+
+
+USAGE
+
+my $informat   = shift;
+
+if ($informat eq "-h")     { die $USAGE; }
+if ($informat eq "--help") { die $USAGE; }
+
+while (my $line = <STDIN>) {
+	
+	
+
+	if ($line !~ /^(\>)/) {
+	
+	$line =~ s/U/T/g;
+	$line =~ s/\./-/g;
+	}
+
+        print "$line";
+}
+
+exit; 
+

--- a/arb-scripts/replace_blanks_with_unclassified.R
+++ b/arb-scripts/replace_blanks_with_unclassified.R
@@ -1,0 +1,23 @@
+# RRR 2/11/16
+# reformat the taxonomy training set so that there are no empty spots.
+# replace empty levels with the word "unclassified"
+# empty spots at genus level yield incorrect p-values in RDP classifier
+
+file.with.blanks.semicolon.delim <- "~/Desktop/TaxonomyTrainingSets/BLASTing/StartFiles12/FWonly_11Feb2016_1452.semicolons.taxonomy"
+reformatted.file.semicolon.delim <- "~/Desktop/TaxonomyTrainingSets/BLASTing/StartFiles12/custom.taxonomy.semicolons"
+
+
+# import taxonomy file:
+numcol <- max(count.fields(file.with.blanks.semicolon.delim, sep=";", quote=""))
+taxonomy.unformatted <- read.table(file = file.with.blanks.semicolon.delim, header = FALSE, sep = ";", quote = "", 
+                                   col.names = 1:numcol, fill = TRUE, stringsAsFactors = FALSE)
+
+# format it:
+taxonomy <- taxonomy.unformatted[ ,1:8]
+taxonomy <- as.matrix(taxonomy)
+index <- which(taxonomy[ ,-1] == "")
+taxonomy[ ,-1][index] <- "unclassified"
+
+# export new version- this is semicolon delim.
+
+write.table(x = taxonomy, file = reformatted.file.semicolon.delim, quote = FALSE, sep = ";", row.names = FALSE, col.names = FALSE)

--- a/arb-scripts/replace_first_semicolon_with_tab.sh
+++ b/arb-scripts/replace_first_semicolon_with_tab.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# RRR 2/11/16
+
+# sed is suuuper fucking annoying because it doesn't recognize tabs.  wtf?
+# bash script to get around that and replace the first semicolon on each line with a tab.
+# because I can just type a fucking tab here.
+
+
+sed 's/;/	/' <custom.taxonomy.semicolons >custom.taxonomy
+
+# and need a semicolon on the end of the line too
+
+#fuck
+
+exit 0

--- a/tax-scripts/RunSteps_1-13.sh
+++ b/tax-scripts/RunSteps_1-13.sh
@@ -5,14 +5,14 @@
 # This lets you run multiple pidents in paralelle which makes it faster.
 # The actual commands in this script are identical to the workflow commands
 # that you type directly into the terminal command line.
-# The only additional code is an array of pidents and a loop to run them repeatedly.
+# The only additional code is an array of pidents and a loop to run them all.
 # RRR 1/12/16
 
 # Choose pidents to test over.
 
-pident=("100" "99" "98" "97" "96" "95" "94")
+pident=("100" "99" "98" "97" "96" "95")
 
-# First Run steps 1-12 to generate databases and folders exactly following workflow
+# First Run steps 1-11 to generate databases and folders exactly following workflow
 # Note: still gotta do the reformatting on your own (step 0)
 
 # 1
@@ -43,23 +43,15 @@ cat otus.above.${pident[0]}.custom.wang.taxonomy otus.below.${pident[0]}.general
 mothur "#classify.seqs(fasta=otus.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
 cat otus.general.wang.taxonomy > otus.general.taxonomy
 # 11
-mothur "#classify.seqs(fasta=custom.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
-mv custom.general.wang.taxonomy custom.general.taxonomy
-# 12
 sed 's/[[:blank:]]/\;/' <otus.${pident[0]}.taxonomy >otus.${pident[0]}.taxonomy.reformatted
 mv otus.${pident[0]}.taxonomy.reformatted otus.${pident[0]}.taxonomy
 sed 's/[[:blank:]]/\;/' <otus.general.taxonomy >otus.general.taxonomy.reformatted
 mv otus.general.taxonomy.reformatted otus.general.taxonomy
-sed 's/[[:blank:]]/\;/' <custom.general.taxonomy >custom.general.taxonomy.reformatted
-mv custom.general.taxonomy.reformatted custom.general.taxonomy
-sed 's/[[:blank:]]/\;/' <custom.taxonomy >custom.custom.taxonomy
-# 13
+# 12
 mkdir conflicts_${pident[0]}
 Rscript find_classification_disagreements.R otus.${pident[0]}.taxonomy otus.general.taxonomy ids.above.${pident[0]} conflicts_${pident[0]} ${pident[0]} 85 70
-mkdir conflicts_database
-Rscript find_classification_disagreements.R custom.custom.taxonomy custom.general.taxonomy NA conflicts_database NA NA 70 database 
 
-# Next Run steps 4-9 and 12-13 with different pident cutoffs
+# Next Run steps 4-9 and 11-12 with different pident cutoffs
 # Define a function called runagain since you repeat this part many times in paralelle
 
 runagain () {
@@ -78,10 +70,10 @@ runagain () {
    mothur "#classify.seqs(fasta=otus.below.$1.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
    # 9
    cat otus.above.$1.custom.wang.taxonomy otus.below.$1.general.wang.taxonomy > otus.$1.taxonomy
-   # 12 a,b
+   # 11 a,b
    sed 's/[[:blank:]]/\;/' <otus.$1.taxonomy >otus.$1.taxonomy.reformatted
    mv otus.$1.taxonomy.reformatted otus.$1.taxonomy
-   # 13 a,b
+   # 12 a,b
    mkdir conflicts_$1
    Rscript find_classification_disagreements.R otus.$1.taxonomy otus.general.taxonomy ids.above.$1 conflicts_$1 $1 85 70
 }
@@ -99,7 +91,8 @@ wait
 # the & lets the levels of the loop run in parallel
 # the wait makes sure all the loops finish before the script exits
 
-# Now run step 14- plotting everything together to choose final pident
+# Now run step 13- plotting everything together to choose final pident
+# First generate the arguments for the command call:
 
 args_string=""
 for p in ${pident[*]}
@@ -107,8 +100,8 @@ do
    args_string+=" conflicts_$p ids.above.$p $p"
 done
 
-# 14
-Rscript plot_classification_disagreements.R otus.abund plots conflicts_database regular NA $args_string
+# 13
+Rscript plot_classification_disagreements.R otus.abund plots regular NA $args_string
 
 printf 'Steps 1-14 have finished running.  Now analysze the plots from step 14 to choose your final pident and generate your final taxonomy file in step 15.  Optionally you can compare to how your taxonomy would have been in step 16. At the end tidy up your working directory with step 17. \n \a'
 sleep .1; printf '\a'; sleep .1; printf '\a'; sleep .1; printf '\a'; sleep .1; printf '\a'; sleep .1; printf '\a'; 

--- a/tax-scripts/RunSteps_1-14.sh
+++ b/tax-scripts/RunSteps_1-14.sh
@@ -23,31 +23,32 @@ blastn -query otus.fasta -task megablast -db custom.db -out otus.custom.blast -o
 blast_formatter -archive otus.custom.blast -outfmt "6 qseqid pident length qlen qstart qend" -out otus.custom.blast.table
 # 4
 Rscript calc_full_length_pident.R otus.custom.blast.table otus.custom.blast.table.modified
+#5
 Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.above.${pident[0]} ${pident[0]} TRUE 
 Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.below.${pident[0]} ${pident[0]} FALSE
-# 5
+# 6
 mkdir plots
 RScript plot_blast_hit_stats.R otus.custom.blast.table.modified ${pident[0]} plots
-# 6
+# 7
 python find_seqIDs_blast_removed.py otus.fasta otus.custom.blast.table.modified ids.missing
 cat ids.below.${pident[0]} ids.missing > ids.below.${pident[0]}.all
-# 7
+# 8
 python create_fastas_given_seqIDs.py ids.above.${pident[0]} otus.fasta otus.above.${pident[0]}.fasta
 python create_fastas_given_seqIDs.py ids.below.${pident[0]}.all otus.fasta otus.below.${pident[0]}.fasta
-# 8
+# 9
 mothur "#classify.seqs(fasta=otus.above.${pident[0]}.fasta, template=custom.fasta,  taxonomy=custom.taxonomy, method=wang, probs=T, processors=2)"
 mothur "#classify.seqs(fasta=otus.below.${pident[0]}.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
-# 9
-cat otus.above.${pident[0]}.custom.wang.taxonomy otus.below.${pident[0]}.general.wang.taxonomy > otus.${pident[0]}.taxonomy
 # 10
+cat otus.above.${pident[0]}.custom.wang.taxonomy otus.below.${pident[0]}.general.wang.taxonomy > otus.${pident[0]}.taxonomy
+# 11
 mothur "#classify.seqs(fasta=otus.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
 cat otus.general.wang.taxonomy > otus.general.taxonomy
-# 11
+# 12
 sed 's/[[:blank:]]/\;/' <otus.${pident[0]}.taxonomy >otus.${pident[0]}.taxonomy.reformatted
 mv otus.${pident[0]}.taxonomy.reformatted otus.${pident[0]}.taxonomy
 sed 's/[[:blank:]]/\;/' <otus.general.taxonomy >otus.general.taxonomy.reformatted
 mv otus.general.taxonomy.reformatted otus.general.taxonomy
-# 12
+# 13
 mkdir conflicts_${pident[0]}
 Rscript find_classification_disagreements.R otus.${pident[0]}.taxonomy otus.general.taxonomy ids.above.${pident[0]} conflicts_${pident[0]} ${pident[0]} 85 70
 
@@ -55,25 +56,25 @@ Rscript find_classification_disagreements.R otus.${pident[0]}.taxonomy otus.gene
 # Define a function called runagain since you repeat this part many times in paralelle
 
 runagain () {
-   # 4 b,c
+   # 5
    Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.above.$1 $1 TRUE 
    Rscript filter_seqIDs_by_pident.R otus.custom.blast.table.modified ids.below.$1 $1 FALSE
-   # 5 b
-   RScript plot_blast_hit_stats.R otus.custom.blast.table.modified $1 plots
    # 6 b
+   RScript plot_blast_hit_stats.R otus.custom.blast.table.modified $1 plots
+   # 7 b
    cat ids.below.$1 ids.missing > ids.below.$1.all
-   # 7
+   # 8
    python create_fastas_given_seqIDs.py ids.above.$1 otus.fasta otus.above.$1.fasta
    python create_fastas_given_seqIDs.py ids.below.$1.all otus.fasta otus.below.$1.fasta
-   # 8
+   # 9
    mothur "#classify.seqs(fasta=otus.above.$1.fasta, template=custom.fasta,  taxonomy=custom.taxonomy, method=wang, probs=T, processors=2)"
    mothur "#classify.seqs(fasta=otus.below.$1.fasta, template=general.fasta, taxonomy=general.taxonomy, method=wang, probs=T, processors=2)"
-   # 9
+   # 10
    cat otus.above.$1.custom.wang.taxonomy otus.below.$1.general.wang.taxonomy > otus.$1.taxonomy
-   # 11 a,b
+   # 12 a,b
    sed 's/[[:blank:]]/\;/' <otus.$1.taxonomy >otus.$1.taxonomy.reformatted
    mv otus.$1.taxonomy.reformatted otus.$1.taxonomy
-   # 12 a,b
+   # 13
    mkdir conflicts_$1
    Rscript find_classification_disagreements.R otus.$1.taxonomy otus.general.taxonomy ids.above.$1 conflicts_$1 $1 85 70
 }
@@ -91,7 +92,7 @@ wait
 # the & lets the levels of the loop run in parallel
 # the wait makes sure all the loops finish before the script exits
 
-# Now run step 13- plotting everything together to choose final pident
+# Now run step 14- plotting everything together to choose final pident
 # First generate the arguments for the command call:
 
 args_string=""
@@ -100,7 +101,7 @@ do
    args_string+=" conflicts_$p ids.above.$p $p"
 done
 
-# 13
+# 14
 Rscript plot_classification_disagreements.R otus.abund plots regular NA $args_string
 
 printf 'Steps 1-14 have finished running.  Now analysze the plots from step 14 to choose your final pident and generate your final taxonomy file in step 15.  Optionally you can compare to how your taxonomy would have been in step 16. At the end tidy up your working directory with step 17. \n \a'

--- a/tax-scripts/plot_classification_disagreements.R
+++ b/tax-scripts/plot_classification_disagreements.R
@@ -9,7 +9,7 @@
 # The variable part is that more pidents can be added, as long as they continue the pattern folder number folder number
 
 # Terminal command line syntax:
-# Rscript plot_classification_disagreements.R otus.abund plots conflicts_database conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98 ...
+# Rscript plot_classification_disagreements.R otus.abund plots conflicts_94 ids.above.94 94 conflicts_96 ids.above.96 96 conflicts_98 ids.above.98 98 ...
 
 #####
 # Receive arguments from terminal command line
@@ -33,13 +33,14 @@ userprefs <- commandArgs(trailingOnly = TRUE)
 #                "../../take14/conflicts_98", "../../take14/ids.above.98", 98,
 #                "../../take14/conflicts_99", "../../take14/ids.above.99", 99,
 #                "../../take14/conflicts_100", "../../take14/ids.above.100", 100)
+# in case you want to add this back to the plots, need to specify this path and un-comment the plotting calls that use it.
+# db.conflicts.folder.path <- "file path to conflicts_database"
 
 otu.table.path <- userprefs[1]
 plots.folder.path <- userprefs[2]
-db.conflicts.folder.path <- userprefs[3]
-forcing.folder.path <- userprefs[4]
-forced.taxonomy.file <-userprefs[5]
-rest.of.arguments <- userprefs[-(1:5)]
+forcing.folder.path <- userprefs[3]
+forced.taxonomy.file <-userprefs[4]
+rest.of.arguments <- userprefs[-(1:4)]
 if (length(rest.of.arguments) > 0){
   pident.folders <- rest.of.arguments[seq(from = 1, to = length(rest.of.arguments), by = 3)]
   ids.file.paths <- rest.of.arguments[seq(from = 1, to = length(rest.of.arguments), by = 3)+1]
@@ -783,18 +784,19 @@ if (forcing.folder.path != "regular"){
   
   otu.summaries <- import.all.conflict.summaries(ConflictFolders = pident.folders, PidentsUsed = pident.values)
   
-  db.summary <- import.database.conflicts(DatabaseFolder = db.conflicts.folder.path)
+  # I removed this from the terminal command also because it is misleading and confusing and doesn't add to the plot. left a commented out input line for use within RStudio at the top.
+  # db.summary <- import.database.conflicts(DatabaseFolder = db.conflicts.folder.path)
   
-  #ignore lineage- it's way higher than the others doesn't fit on graphs
+  # ignore lineage- it's way higher than the others doesn't fit on graphs
   otu.summaries <- otu.summaries[-5, ]
-  db.summary <- db.summary[-5, ]
+  # db.summary <- db.summary[-5, ]
   
   plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path)
   plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, y.axis.limit = 10)
   # plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE)
   # plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE, y.axis.limit = 1)
-  plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, DBconflicts = db.summary, y.axis.limit = max(db.summary[,2]))
-  plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, DBconflicts = db.summary)
+  # plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, DBconflicts = db.summary, y.axis.limit = max(db.summary[,2]))
+  # plot.num.forced(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, DBconflicts = db.summary)
   
   # plot.num.classified.outs(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = FALSE)
   plot.num.classified.outs(ConflictSummaryTable = otu.summaries, ResultsFolder = plots.folder.path, AsPercent = TRUE)


### PR DESCRIPTION
These changes are predominantly to the workflow directions. 
1. I took out the database comparison steps that we used to find drift btwn the databases. 
   - I created a new folder called `arb-scripts/` that contains the ones that used to be in the workflow, and the ones that I'd made in the arb repo (that we should just delete now btw makes more sense to have them here since many require intermediate workflow files)
   - I edited the `plot_classification_disagreements.R` script so that it doesn't require the database comparison results.  Seems like everyone agreed it didn't add to the interpretation of the forcing graph.  Also edited the script calls in the workflow to match.
   - I made an ARB workflow draft.  To keep track of what all the scripts I made are and when in the workflow you use them.  I was already forgetting...
2. I edited the workflow directions.  
   - I split step 4 into 2 steps, so that now `calc_full_length_pident.R` is in a separate step than `filter_seqIDs_by_pident.R` 
   - I edited the descriptions from step 1 to step 8 to make the format simpler and more uniform.  Now all of them just go through the arguments instead of the flags and file names separately. 
   - I edited the LazyRun (now `RunSteps_1-14.sh`) accordingly.
