### PR TITLE
Compatibility with SILVA Database

### DIFF
--- a/tax-scripts/TaxAss_Directions.Rmd
+++ b/tax-scripts/TaxAss_Directions.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "TaxAss Workflow"
 author: "Robin Rohwer"
-date: "last updated: 11/5/2017"
+date: "last updated: 1/23/2018"
 output: 
   html_document:
     toc: true
@@ -45,13 +45,14 @@ This is a list of all the steps and possible commands. There are details for eac
 		sed 's/$/;/' <NoSpaces >EndLineSemicolons
 		mv EndLineSemicolons general.taxonomy
 		rm NoSpaces
+	for SILVA database as general.taxonomy
+	  python getSilvaFromMothur.py
+	  python convertFreshTrainToSilva.py
 	for aligned fasta files:
 		sed 's/-//g' <aligned.fasta >otus.fasta
 	for mothur .count_table as OTU table:
 		Rscript reformat_mothur_OTU_tables.R StupidLongMothurName.count_table count_table otus.abund
 
-
-		
 1. make BLAST database file (blast)
 	makeblastdb -dbtype nucl -in custom.fasta -input_type fasta -parse_seqids -out custom.db
 
@@ -192,8 +193,11 @@ Database      | Version | File Name          | Download From
 --------------|---------|--------------------|-------------------------  
 FreshTrain    | 18Aug2016 | FreshTrain18Aug2016.zip | https://github.com/McMahonLab/TaxAss/FreshTrain-files<br>(You can download the single zip file by clicking on it)
 Greengenes    | May 2013  | gg_13_5.fasta <br> gg_13_5_taxonomy.txt| greengenes.secondgenome.com/downloads
+SILVA | Release 132 | Silva.nr_v132.tgz | Download the mothur-compatible SILVA reference files for SILVA release 132 from https://www.mothur.org/wiki/Silva_reference_files by clicking on the `Full length sequences and taxonomy references` link. This should link directly to https://www.mothur.org/w/images/3/32/Silva.nr_v132.tgz.
 
-Unfortunately you can't download a useable (consistent delimiters/column names) version of SILVA diectly from their database. You'd have to import it into ARB and create that yourself. Another option is to use the version created by mothur or qiime, which you can find on their websites but which aren't necessarily the most up to date version. Feel free to share how you used SILVA in a github issue or email (robin.rohwer@gmail.com) and I'll add it to the instructions here.
+To use the SILVA database with TaxAss, you must ensure that your custom database contains the same taxonomic structure as SILVA. Differences in classification between the databases can be found by classifying your custom database using SILVA and running the `find_classification_disagreements.R` script included in this repository. Additional details can be found by reading the `Database_Improvement_Workflow.txt` in the `arb-scripts` folder included in this repository, or by contacting the authors via Github or e-mail.
+
+If you want to use the FreshTrain as your custom database, we have provided the required scripts: `getSilvaFromMothur.py` and `convertFreshTrainToSilva.py`. Both are included in this repostitory. As of 2018-01-23, these scripts have been tested only with SILVA Release 132 and Fresh Train release 18 August 2016.
 
 __________________________________________________________________________________________
 
@@ -278,12 +282,28 @@ ___________
 
 #### Format the Silva database... 
 
-<span style="color:grey">made shell script reformat_silva.sh but it doesn't work b/c silva is stupid and uses inconsistent delimiters w/ inconsistent column numbers. 
-there's no way to make a compatible file without opening it in ARB and exporting in a different format yourself.
-mothur and qiime did it for you, but they're also out of date. wtf SILVA? literally noone could use that format for anything.
-(see analysis notes 12-5-16 for this saga)</span>
+If you want to use the FreshTrain as your custom database, we have provided the required scripts: `getSilvaFromMothur.py` and `convertFreshTrainToSilva.py`. Both are included in this repostitory. As of 2018-01-23, these scripts have been tested only with SILVA Release 132 and Fresh Train release 18 August 2016.
 
-Best bet is to pull it from the mothur website. Note that SILVA only includes names to genus, although it does contain more references.
+To use the SILVA database with TaxAss, you must first run two scripts: `getSilvaFromMothur.py` and `convertFreshTrainToSilva.py`. Both are included in this repostitory. As of 2018-01-23, these scripts have been tested only with SILVA Release 132 and Fresh Train release 18 August 2016.
+
+The script `getSilvaFromMothur.py` downloads the mothur-compatible SILVA reference files (Release 132) and processes the fasta and taxonomy files so they're compatible with TaxAss.
+
+```
+python getSilvaFromMothur.py
+```
+
+Outputs: two files, `general.taxonomy` and `general.fasta` that are formatted correctly for TaxAss.
+
+The script `convertFreshTrainToSilva.py` updates the taxonomic tree structure of the FreshTrain (18 August 2016 release) to reflect the taxonomic structure used in SILVA (Release 132). For each freshwater lineage, class- and order-level taxonomic classifications are updated to reflect the placement of those sequences in SILVA, as determined using the `find_classification_disagreements.R` script in this package. (See comments contained within `convertFreshTrainToSilva.py` for details on re-assigned taxonomies, and `Database_Improvement_Workflow.txt` in the `arb-scripts folder` for the workflow.) In addition, any sequences not belonging to a freshwater-lineage were removed from the FreshTrain.
+
+```
+python convertFreshTrainToSilva.py
+```
+
+Required files: two files, `general.taxonomy` and `general.fasta` obtained from running `getSilvaFromMothur.py`.
+Required files: two files, `custom.taxonomy` and `custom.fasta` obtained from extracting the `FreshTrain18Aug2016.zip` file included with this repository.
+
+Outputs: two files, `custom.taxonomy` and `custom.fasta`, representing new versions of the FreshTrain database that have the same taxonomic structure as SILVA.
 
 ______________________
 

--- a/tax-scripts/TaxAss_Directions.html
+++ b/tax-scripts/TaxAss_Directions.html
@@ -216,7 +216,7 @@ div.tocify {
 
 <h1 class="title toc-ignore">TaxAss Workflow</h1>
 <h4 class="author"><em>Robin Rohwer</em></h4>
-<h4 class="date"><em>last updated: 11/5/2017</em></h4>
+<h4 class="date"><em>last updated: 1/23/2018</em></h4>
 
 </div>
 
@@ -248,13 +248,14 @@ pre code, pre, code {
         sed 's/$/;/' &lt;NoSpaces &gt;EndLineSemicolons
         mv EndLineSemicolons general.taxonomy
         rm NoSpaces
+    for SILVA database as general.taxonomy
+      python getSilvaFromMothur.py
+      python convertFreshTrainToSilva.py
     for aligned fasta files:
         sed 's/-//g' &lt;aligned.fasta &gt;otus.fasta
     for mothur .count_table as OTU table:
         Rscript reformat_mothur_OTU_tables.R StupidLongMothurName.count_table count_table otus.abund
 
-
-        
 1. make BLAST database file (blast)
     makeblastdb -dbtype nucl -in custom.fasta -input_type fasta -parse_seqids -out custom.db
 
@@ -440,9 +441,16 @@ export PATH=~/mothur:$PATH</code></pre>
 <td>gg_13_5.fasta <br> gg_13_5_taxonomy.txt</td>
 <td>greengenes.secondgenome.com/downloads</td>
 </tr>
+<tr class="odd">
+<td>SILVA</td>
+<td>Release 132</td>
+<td>Silva.nr_v132.tgz</td>
+<td>Download the mothur-compatible SILVA reference files for SILVA release 132 from <a href="https://www.mothur.org/wiki/Silva_reference_files" class="uri">https://www.mothur.org/wiki/Silva_reference_files</a> by clicking on the <code>Full length sequences and taxonomy references</code> link. This should link directly to <a href="https://www.mothur.org/w/images/3/32/Silva.nr_v132.tgz" class="uri">https://www.mothur.org/w/images/3/32/Silva.nr_v132.tgz</a>.</td>
+</tr>
 </tbody>
 </table>
-<p>Unfortunately you can’t download a useable (consistent delimiters/column names) version of SILVA diectly from their database. You’d have to import it into ARB and create that yourself. Another option is to use the version created by mothur or qiime, which you can find on their websites but which aren’t necessarily the most up to date version. Feel free to share how you used SILVA in a github issue or email (<a href="mailto:robin.rohwer@gmail.com">robin.rohwer@gmail.com</a>) and I’ll add it to the instructions here.</p>
+<p>To use the SILVA database with TaxAss, you must ensure that your custom database contains the same taxonomic structure as SILVA. Differences in classification between the databases can be found by classifying your custom database using SILVA and running the <code>find_classification_disagreements.R</code> script included in this repository. Additional details can be found by reading the <code>Database_Improvement_Workflow.txt</code> in the <code>arb-scripts</code> folder included in this repository, or by contacting the authors via Github or e-mail.</p>
+<p>If you want to use the FreshTrain as your custom database, we have provided the required scripts: <code>getSilvaFromMothur.py</code> and <code>convertFreshTrainToSilva.py</code>. Both are included in this repostitory. As of 2018-01-23, these scripts have been tested only with SILVA Release 132 and Fresh Train release 18 August 2016.</p>
 <hr />
 </div>
 </div>
@@ -548,8 +556,15 @@ If there are dashes it makes it difficult to switch between aligned and unaligne
 </div>
 <div id="format-the-silva-database" class="section level4">
 <h4>Format the Silva database…</h4>
-<p><span style="color:grey">made shell script reformat_silva.sh but it doesn’t work b/c silva is stupid and uses inconsistent delimiters w/ inconsistent column numbers. there’s no way to make a compatible file without opening it in ARB and exporting in a different format yourself. mothur and qiime did it for you, but they’re also out of date. wtf SILVA? literally noone could use that format for anything. (see analysis notes 12-5-16 for this saga)</span></p>
-<p>Best bet is to pull it from the mothur website. Note that SILVA only includes names to genus, although it does contain more references.</p>
+<p>If you want to use the FreshTrain as your custom database, we have provided the required scripts: <code>getSilvaFromMothur.py</code> and <code>convertFreshTrainToSilva.py</code>. Both are included in this repostitory. As of 2018-01-23, these scripts have been tested only with SILVA Release 132 and Fresh Train release 18 August 2016.</p>
+<p>To use the SILVA database with TaxAss, you must first run two scripts: <code>getSilvaFromMothur.py</code> and <code>convertFreshTrainToSilva.py</code>. Both are included in this repostitory. As of 2018-01-23, these scripts have been tested only with SILVA Release 132 and Fresh Train release 18 August 2016.</p>
+<p>The script <code>getSilvaFromMothur.py</code> downloads the mothur-compatible SILVA reference files (Release 132) and processes the fasta and taxonomy files so they’re compatible with TaxAss.</p>
+<pre><code>python getSilvaFromMothur.py</code></pre>
+<p>Outputs: two files, <code>general.taxonomy</code> and <code>general.fasta</code> that are formatted correctly for TaxAss.</p>
+<p>The script <code>convertFreshTrainToSilva.py</code> updates the taxonomic tree structure of the FreshTrain (18 August 2016 release) to reflect the taxonomic structure used in SILVA (Release 132). For each freshwater lineage, class- and order-level taxonomic classifications are updated to reflect the placement of those sequences in SILVA, as determined using the <code>find_classification_disagreements.R</code> script in this package. (See comments contained within <code>convertFreshTrainToSilva.py</code> for details on re-assigned taxonomies, and <code>Database_Improvement_Workflow.txt</code> in the <code>arb-scripts folder</code> for the workflow.) In addition, any sequences not belonging to a freshwater-lineage were removed from the FreshTrain.</p>
+<pre><code>python convertFreshTrainToSilva.py</code></pre>
+<p>Required files: two files, <code>general.taxonomy</code> and <code>general.fasta</code> obtained from running <code>getSilvaFromMothur.py</code>. Required files: two files, <code>custom.taxonomy</code> and <code>custom.fasta</code> obtained from extracting the <code>FreshTrain18Aug2016.zip</code> file included with this repository.</p>
+<p>Outputs: two files, <code>custom.taxonomy</code> and <code>custom.fasta</code>, representing new versions of the FreshTrain database that have the same taxonomic structure as SILVA.</p>
 <hr />
 </div>
 </div>

--- a/tax-scripts/convertFreshTrainToSilva.py
+++ b/tax-scripts/convertFreshTrainToSilva.py
@@ -179,5 +179,5 @@ outFastaHandle.close()
 
 os.remove(inputFasta)
 os.remove(inputTaxon)
-os.move(outputFasta, inputFasta)
-os.move(outputTaxon, inputTaxon)
+os.rename(outputFasta, inputFasta)
+os.rename(outputTaxon, inputTaxon)

--- a/tax-scripts/convertFreshTrainToSilva.py
+++ b/tax-scripts/convertFreshTrainToSilva.py
@@ -1,0 +1,183 @@
+###############################################################################
+# convertFreshTrain.py
+# Copyright (c) 2018, Joshua J Hamilton, Robin R Rohwer, and Katherine D McMahon
+# Affiliation: Department of Bacteriology
+#              University of Wisconsin-Madison, Madison, Wisconsin, USA
+# URL: http://http://mcmahonlab.wisc.edu/
+# All rights reserved.
+################################################################################
+# Update the taxonomic strucutre of the FreshTrain reference database to be 
+# compatabile with the mothur-compatible SILVA reference files.
+#
+# Tested on FreshTrain18Aug2016 and the mothur-compatible reference files from
+# SILVA v132.
+#
+# Performs the following operations:
+# Removes any sequence not assigned to a freshwater-specific lineage. We were
+# too lazy to map the taxonomy of these individual sequences to SILVA. For the
+# most part they aren't freshwater-specific, anyway.
+#
+# Update the taxonomy of any freshwater-specific lineages, as follows:
+# SILVA Classification	FreshTrain Classification	Applies to Lineage
+# c__Bacteroidia	c__[Saprospirae]	bacI, bac IV
+# o__Chitinophagales	o__[Saprospirales]	bacI, bac IV
+# c__Bacteroidia	c__Flavobacteriia	bacII, bacV
+# c__Bacteroidia	c__Cytophagia	bacIII
+# c__Bacteroidia	c__Sphingobacteriia	bacVI
+# c__Gammaproteobacteria	c__Betaproteobacteria	betI, betII, betIII, betIV, betV, betVII
+# o__Betaproteobacteriales	o__Burkholderiales	betI, betII, betIII, bet VII
+# o__Betaproteobacteriales	o__Methylophilales	betIV
+# o__Betaproteobacteriales	o__undefined	betV
+# c__Verrucomicrobiae	c__[Methylacidiphilae]	LD19
+# c__Verrucomicrobiae	c__[Spartobacteria]	verI-A, verI-B
+# o__Chthoniobacterales	o__[Chthoniobacterales]	verI-A, verI-B
+# o__Frankiales	o__Actinomycetales	acI, acSTL, acTH1
+# o__Micrococcales	o__Actinomycetales	acIII
+# o__Microtrichales	o__Acidimicrobiales	acIV
+# o__Corynebacteriales	o__Actinomycetales	acTH2
+# o__uncultured	o__Acidimicrobiales	acV
+# o__SAR11_clade	o__Rickettsiales	alfV
+# o__Acetobacterales	o__Rhodospirillales	alfVIII
+# o__Micrococcales	o__Actinomycetales	Luna1, Luna3
+# Note: SILVA represents the betaproteobacteria as an order within the
+# gammaproteobacteria, so all 'bet' lineages get classified as gammaprotoes
+# at the class level.
+################################################################################
+
+#%%#############################################################################
+### Import packages
+################################################################################
+
+from Bio import SeqIO
+import os
+
+#%%#############################################################################
+### User-defined files and other declarations
+################################################################################
+
+inputFasta = 'custom.fasta'
+inputTaxon = 'custom.taxonomy'
+outputFasta = 'temp.fasta'
+outputTaxon = 'temp.taxonomy'
+
+# Valid lineages. We discard any sequence not belonging to this lineage.
+lineageList = ['acI','acIII','acIV','acSTL','acTH1','acTH2','acV',
+               'alfI','alfI-A','alfI-B','alfII','alfIII','alfIV','alfV','alfVI','alfVII','alfVIII',
+               'bacI','bacII','bacIII','bacIV','bacV','bacVI',
+               'betI','betII','betIII','betIV','betV','betVII',
+               'gamI','gamII','gamIII','gamIV','gamV',
+               'LD19','Luna1','Luna3','verI-A','verI-B',
+]
+
+# List of sequence IDs that don't have a valid lineage. Will get populated
+# when correcting the taxonomy file.
+badLineageList = []
+
+# Dictionary of class-level disagreements. For each lineage, will update the
+# class with the appropriate SILVA class-level taxonomic assignment
+newClassDict = {
+               'bacI': 'c__Bacteroidia',
+               'bacII': 'c__Bacteroidia',
+               'bacIII': 'c__Bacteroidia',
+               'bacIV': 'c__Bacteroidia',
+               'bacV': 'c__Bacteroidia',
+               'bacVI': 'c__Bacteroidia',
+               'betI': 'c__Gammaproteobacteria',
+               'betII': 'c__Gammaproteobacteria',
+               'betIII': 'c__Gammaproteobacteria',
+               'betIV': 'c__Gammaproteobacteria',
+               'betV': 'c__Gammaproteobacteria',
+               'betVII': 'c__Gammaproteobacteria',
+               'LD19': 'c__Verrucomicrobiae',
+               'verI-A': 'c__Verrucomicrobiae',
+               'verI-B': 'c__Verrucomicrobiae'
+        }
+
+# Dictionary of order-level disagreements. For each lineage, will update the
+# order with the appropriate SILVA order-level taxonomic assignment
+newOrderDict = {
+        'acI': 'o__Frankiales',
+        'acIII': 'o__Micrococcales',
+        'acIV': 'o__Microtrichales',
+        'acSTL': 'o__Frankiales',
+        'acTH1': 'o__Frankiales',
+        'acTH2': 'o__Corynebacteriales',
+        'acV': 'o__uncultured',
+        'alfV': 'o__SAR11_clade',
+        'alfVIII': 'o__Acetobacterales',
+        'bacI': 'o__Chitinophagales',
+        'bacIV': 'o__Chitinophagales',
+        'betI': 'o__Betaproteobacteriales',
+        'betII': 'o__Betaproteobacteriales',
+        'betIII': 'o__Betaproteobacteriales',
+        'betIV': 'o__Betaproteobacteriales',
+        'betV': 'o__Betaproteobacteriales',
+        'betVII': 'o__Betaproteobacteriales',
+        'Luna1': 'o__Micrococcales',
+        'Luna3': 'o__Micrococcales',
+        'verI-A': 'o__Chthoniobacterales',
+        'verI-B': 'o__Chthoniobacterales'
+        }
+
+
+#%%#############################################################################
+### Read in the taxonomy file and remove any sequences that don't have a valid
+### lineage. Record the seequence IDs.
+################################################################################
+
+inTaxonHandle = open(inputTaxon, 'r')
+outTaxonHandle = open(outputTaxon, 'w')
+
+for curLine in inTaxonHandle.readlines():
+    curLine = curLine.strip()    
+
+    # Split along a tab to separate seqID from taxonomy
+    # Grab the lineage from the taxonomy information
+    seqID = curLine.split('\t')[0]
+    seqTaxon = curLine.split(';')
+    lineage = seqTaxon[4]
+    
+    # Check if the class needs to be updated and update id
+    if lineage in newClassDict.keys():
+        seqTaxon[2] = newClassDict[lineage]
+        
+    # Check if the class needs to be updated and update id
+    if lineage in newOrderDict.keys():
+        seqTaxon[3] = newOrderDict[lineage]
+    
+    # If the lineage is valid, write the new taxonomy file
+    if lineage in lineageList:
+        newTaxonString = seqID+'\t'+';'.join(seqTaxon)
+        outTaxonHandle.write(newTaxonString+'\n')    
+
+    # Otherwise, record the seqID
+    else:
+        badLineageList.append(seqID)
+
+outTaxonHandle.close()
+
+#%%#############################################################################
+### Read in the sequence file and drop all sequences that don't have a valid
+### lineage
+################################################################################
+
+inFastaHandle = open(inputFasta, 'r')
+outFastaHandle = open(outputFasta, 'w')
+
+for curRecord in SeqIO.parse(inFastaHandle, 'fasta') :
+
+    # If the lineage is valid, write the new taxonomy file
+    if curRecord.name not in badLineageList:        
+        outFastaHandle.write('>'+curRecord.id+'\n')
+        outFastaHandle.write(str(curRecord.seq)+'\n')
+    
+outFastaHandle.close()
+
+#%%#############################################################################
+### Clean up your files
+################################################################################
+
+os.remove(inputFasta)
+os.remove(inputTaxon)
+os.move(outputFasta, inputFasta)
+os.move(outputTaxon, inputTaxon)

--- a/tax-scripts/getSilvaFromMothur.py
+++ b/tax-scripts/getSilvaFromMothur.py
@@ -1,0 +1,107 @@
+###############################################################################
+# processSilva.py
+# Copyright (c) 2018, Joshua J Hamilton, Robin R Rohwer, and Katherine D McMahon
+# Affiliation: Department of Bacteriology
+#              University of Wisconsin-Madison, Madison, Wisconsin, USA
+# URL: http://http://mcmahonlab.wisc.edu/
+# All rights reserved.
+################################################################################
+# Download mothur-compatible SILVA files and reformat for use with TaxAss
+################################################################################
+
+#%%#############################################################################
+### Import packages
+################################################################################
+
+from Bio import SeqIO
+import os
+import re
+import tarfile
+import urllib
+
+#%%#############################################################################
+### User-defined files
+################################################################################
+fileName = 'general.tgz'
+outputFasta = 'general.fasta'
+outputTaxon = 'general.taxonomy'
+
+#%%#############################################################################
+### Download the unzip the NR database as formatted by Pat
+################################################################################
+
+urllib.urlretrieve('https://www.mothur.org/w/images/3/32/Silva.nr_v132.tgz', fileName)
+tarFile = tarfile.open(fileName, 'r:gz')
+tarFile.extractall()
+tarFile.close()
+
+#%%#############################################################################
+### Read in the alignment file and reformat
+################################################################################
+inFastaHandle = open('silva.nr_v132.align', 'r')
+outFastaHandle = open(outputFasta, 'w')
+
+for record in SeqIO.parse(inFastaHandle, 'fasta') :
+
+    # Remove record description so fasta gets printed without it
+    record.id = re.sub('\.', '', record.id)
+
+    # Write the results to file
+    record.seq = re.sub('\.', '', str(record.seq))
+    record.seq = re.sub('-', '', str(record.seq))
+    
+    outFastaHandle.write('>'+record.id+'\n')
+    outFastaHandle.write(record.seq+'\n')
+    
+outFastaHandle.close()
+        
+#%%#############################################################################
+### Read in the taxonomy file and reformat
+################################################################################
+inTaxonHandle = open('silva.nr_v132.tax', 'r')
+outTaxonHandle = open(outputTaxon, 'w')
+
+for curLine in inTaxonHandle.readlines():
+    curLine = curLine.strip()    
+
+    # 1st part is the seqID, remove the '.' for consistency
+    seqID = curLine.split('\t')[0]
+    seqID = re.sub('\.', '', seqID)
+
+    taxonString = curLine.split('\t')[1]
+    taxonArray = taxonString.split(';')
+    
+    if len(taxonArray) == 7:
+        newTaxonString = seqID+'\t'+'k__'+taxonArray[0]+';p__'+taxonArray[1]+ \
+        ';c__'+taxonArray[2]+';o__'+taxonArray[3]+';f__'+taxonArray[4]+ \
+        ';g__'+taxonArray[5]+';s__'+taxonArray[6]+';'
+    elif len(taxonArray) == 6:
+        newTaxonString = seqID+'\t'+'k__'+taxonArray[0]+';p__'+taxonArray[1]+ \
+        ';c__'+taxonArray[2]+';o__'+taxonArray[3]+';f__'+taxonArray[4]+ \
+        ';g__'+taxonArray[5]+';s__'+';'
+    elif len(taxonArray) == 5:
+        newTaxonString = seqID+'\t'+'k__'+taxonArray[0]+';p__'+taxonArray[1]+ \
+        ';c__'+taxonArray[2]+';o__'+taxonArray[3]+';f__'+taxonArray[4]+ \
+        ';g__'+';s__'+';'
+    elif len(taxonArray) == 4:
+        newTaxonString = seqID+'\t'+'k__'+taxonArray[0]+';p__'+taxonArray[1]+ \
+        ';c__'+taxonArray[2]+';o__'+taxonArray[3]+';f__'+';g__'+';s__'+';'
+    elif len(taxonArray) == 3:
+        newTaxonString = seqID+'\t'+'k__'+taxonArray[0]+';p__'+taxonArray[1]+ \
+        ';c__'+taxonArray[2]+';o__'+';f__'+';g__'+';s__'+';'
+    elif len(taxonArray) == 2:
+        newTaxonString = seqID+'\t'+'k__'+taxonArray[0]+';p__'+taxonArray[1]+ \
+        ';c__'+';o__'+';f__'+';g__'+';s__'+';'
+    elif len(taxonArray) == 1:
+        newTaxonString = seqID+'\t'+'k__'+taxonArray[0]+';p__'+';c__'+';o__'+';f__'+';g__'+';s__'+';'
+
+    outTaxonHandle.write(newTaxonString+'\n')
+        
+outTaxonHandle.close()
+
+#%%#############################################################################
+### Clean up your files
+################################################################################
+os.remove(fileName)
+os.remove('silva.nr_v123.align')
+os.remove('silva.nr_v123.tax')

--- a/tax-scripts/getSilvaFromMothur.py
+++ b/tax-scripts/getSilvaFromMothur.py
@@ -103,5 +103,5 @@ outTaxonHandle.close()
 ### Clean up your files
 ################################################################################
 os.remove(fileName)
-os.remove('silva.nr_v123.align')
-os.remove('silva.nr_v123.tax')
+os.remove('silva.nr_v132.align')
+os.remove('silva.nr_v132.tax')


### PR DESCRIPTION
Added two new scripts, `getSilvaFromMothur.py` and `convertFreshTrainToSilva.py`.

The script `getSilvaFromMothur.py` downloads the [mothur-compatible SILVA reference files](https://www.mothur.org/wiki/Silva_reference_files) (Release 132) and processes the `fasta` and `taxonomy` files so they're compatible with TaxAss.

The script `convertFreshTrainToSilva.py` updates the taxonomic tree structure of the FreshTrain (18 August 2016 release) to reflect the taxonomic structure used in SILVA (Release 132). For each freshwater lineage, class- and order-level taxonomic classifications are updated to reflect the placement of those sequences in SILVA, as determined using the `find_classification_disagreements.R` script in this package. (See the `convertFreshTrainToSilva.py` for details on -re-assigned taxonomies, and `Database_Improvement_Workflow.txt` in the `arb-scripts` folder for the workflow.) In addition, any sequences not belonging to a freshwater-lineage were removed from the FreshTrain.

Updated `TaxAss_Directions.Rmd` and `TaxAss_Directions.html` with instructions on using the SILVA database and running these scripts.